### PR TITLE
Feat/set custom exception

### DIFF
--- a/src/main/java/com/studypals/global/exceptions/BaseException.java
+++ b/src/main/java/com/studypals/global/exceptions/BaseException.java
@@ -1,0 +1,37 @@
+package com.studypals.global.exceptions;
+
+import com.studypals.global.exceptions.errorCode.ErrorCode;
+
+/**
+ * 모든 커스텀 예외 클래스의 추상 부모 클래스입니다. 자체적으로는 사용되지 않습니다.
+ * <p>
+ * 클라이언트로의 응답 코드, 상태 메시지, 내부 로그 메시지를 분리하여 저장합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@code RuntimeException} 을 상속받으며 언체크 예외입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code BaseException(ErrorCode errorCode)} <br>
+ * 내부 로그 메시지를 담지 않는 예외를 생성합니다. 단, protected로 점겨 있어 상속 객체만 사용이 가능합니다. <br>
+ * {@code BaseException(ErrorCode errorCode, String logMessage)} <br>
+ * 내부 로그 메시지를 담는 예외를 생성합니다. 단, protected로 점겨 있어 상속 객체만 사용이 가능합니다. <br>
+
+ *
+ * @author jack8
+ * @see RuntimeException
+ * @see ErrorCode
+ * @since 2025-03-31
+ */
+public abstract class BaseException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    protected BaseException(ErrorCode errorCode) {
+        super(null, null, false, false);
+        this.errorCode = errorCode;
+    }
+
+    protected BaseException(ErrorCode errorCode, String logMessage) {
+        super(logMessage, null, false, false);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/BaseException.java
+++ b/src/main/java/com/studypals/global/exceptions/BaseException.java
@@ -24,14 +24,23 @@ import com.studypals.global.exceptions.errorCode.ErrorCode;
  */
 public abstract class BaseException extends RuntimeException {
     private final ErrorCode errorCode;
+    private final String logMessage;
 
     protected BaseException(ErrorCode errorCode) {
-        super(null, null, false, false);
+        super(errorCode.getMessage(), null, false, false);
         this.errorCode = errorCode;
+        this.logMessage = "[client] " + errorCode.getMessage();
     }
 
     protected BaseException(ErrorCode errorCode, String logMessage) {
-        super(logMessage, null, false, false);
+        super(errorCode.getMessage(), null, false, false);
         this.errorCode = errorCode;
+        this.logMessage = "[internal] " + logMessage;
+    }
+
+    protected BaseException(ErrorCode errorCode, String clientMessage, String logMessage) {
+        super(clientMessage, null, false, false);
+        this.errorCode = errorCode;
+        this.logMessage = "[internal] " + logMessage;
     }
 }

--- a/src/main/java/com/studypals/global/exceptions/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/AuthErrorCode.java
@@ -1,7 +1,6 @@
 package com.studypals.global.exceptions.errorCode;
 
 import com.studypals.global.responses.ResponseCode;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
  * @see ResponseCode
  * @since 2025-03-31
  */
-@Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 

--- a/src/main/java/com/studypals/global/exceptions/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/AuthErrorCode.java
@@ -1,0 +1,47 @@
+package com.studypals.global.exceptions.errorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 커스텀 예외가 클라이언트로 반환할 데이터를 정의하고 관리합니다.
+ * <p>
+ * 상황에 대한 코드, 클라이언트로의 응답 코드 및 메시지를 가지며, 그 명명 규칙은 문서를 참조해야 합니다.
+ * 해당 {@code AuthErrorCode} 는 {@link com.studypals.global.exceptions.exception.AuthException AuthException}에서 사용되며, <br>
+ * {@code NAME("code", HttpStatus.STATUS, "some message")}로 저장됩니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link ErrorCode}의 구현체입니다.
+ *
+ * @author jack8
+ * @see ErrorCode
+ * @see com.studypals.global.exceptions.exception.AuthException AuthException
+ * @since 2025-03-31
+ */
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    UNKNOWN_USER("10-1", HttpStatus.NOT_FOUND, "can't find user")
+    ;
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/errorCode/AuthErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/AuthErrorCode.java
@@ -1,15 +1,16 @@
 package com.studypals.global.exceptions.errorCode;
 
+import com.studypals.global.responses.ResponseCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 /**
- * 커스텀 예외가 클라이언트로 반환할 데이터를 정의하고 관리합니다.
+ * 인증/인가 및 유저 조회에서 발생하는 예외에 대한 상수 값을 정의합니다.
  * <p>
  * 상황에 대한 코드, 클라이언트로의 응답 코드 및 메시지를 가지며, 그 명명 규칙은 문서를 참조해야 합니다.
  * 해당 {@code AuthErrorCode} 는 {@link com.studypals.global.exceptions.exception.AuthException AuthException}에서 사용되며, <br>
- * {@code NAME("code", HttpStatus.STATUS, "some message")}로 저장됩니다.
+ * {@code NAME(ResponseCode, HttpStatus.STATUS, "some message")}로 저장됩니다.
  *
  * <p><b>상속 정보:</b><br>
  * {@link ErrorCode}의 구현체입니다.
@@ -17,22 +18,31 @@ import org.springframework.http.HttpStatus;
  * @author jack8
  * @see ErrorCode
  * @see com.studypals.global.exceptions.exception.AuthException AuthException
+ * @see ResponseCode
  * @since 2025-03-31
  */
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-    UNKNOWN_USER("10-1", HttpStatus.NOT_FOUND, "can't find user")
-    ;
+    USER_NOT_FOUND(ResponseCode.USER_SEARCH, HttpStatus.NOT_FOUND, "can't find user"),
+    USER_CREATE_FAIL(ResponseCode.USER_CREATE, HttpStatus.BAD_REQUEST, "failed to create user"),
+    USER_UPDATE_FAIL(ResponseCode.USER_UPDATE, HttpStatus.BAD_REQUEST, "failed to update user"),
+    USER_DELETE_FAIL(ResponseCode.USER_DELETE, HttpStatus.BAD_REQUEST, "failed to delete user"),
+    SIGNUP_FAIL(ResponseCode.USER_SIGNUP, HttpStatus.BAD_REQUEST, "failed to sign up"),
+    LOGIN_FAIL(ResponseCode.USER_LOGIN, HttpStatus.UNAUTHORIZED, "failed to login"),
+    USER_AUTH_FAIL(ResponseCode.USER_AUTH_CHECK, HttpStatus.FORBIDDEN, "user authorization failed");
 
-    private final String code;
+
+
+
+    private final ResponseCode responseCode;
     private final HttpStatus status;
     private final String message;
 
     @Override
     public String getCode() {
-        return code;
+        return responseCode.getCode();
     }
 
     @Override

--- a/src/main/java/com/studypals/global/exceptions/errorCode/ErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.studypals.global.exceptions.errorCode;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * 모든 errorCode enum class 의 인터페이스입니다. 해당 enum class 가 가져야 할 필드를 정의합니다.
+ * <p>
+ * 상태에 대한 코드 및 http status, message에 대한 getter 메서드를 정의합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 추후 모든 ErrorCode 종류의 구현체 클래스의 부모 인터페이스입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * 존재하지 않습니다.
+ *
+ * @author jack8
+ * @since 2025-03-31
+ */
+public interface ErrorCode {
+    String getCode();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/studypals/global/exceptions/errorCode/GroupErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/GroupErrorCode.java
@@ -1,7 +1,6 @@
 package com.studypals.global.exceptions.errorCode;
 
 import com.studypals.global.responses.ResponseCode;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
  * @see com.studypals.global.exceptions.exception.GroupException GroupException
  * @since 2025-04-02
  */
-@Getter
 @RequiredArgsConstructor
 public enum GroupErrorCode implements ErrorCode {
     // U02: User <-> Group 관련

--- a/src/main/java/com/studypals/global/exceptions/errorCode/GroupErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/GroupErrorCode.java
@@ -1,0 +1,57 @@
+package com.studypals.global.exceptions.errorCode;
+
+import com.studypals.global.responses.ResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 유저 그룹 관리에서 발생하는 예외에 대한 상수 값을 정의합니다.
+ * <p>
+ * 상황에 대한 코드, 클라이언트로의 응답 코드 및 메시지를 가지며, 그 명명 규칙은 문서를 참조해야 합니다.
+ * 해당{@code StudyErrorCode} 는 {@link com.studypals.global.exceptions.exception.GroupException GroupException} 에서 사용되며 <br>
+ * {@code NAME(ResponseCode, HttpStatus.STATUS, "some message")}로 저장됩니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link ErrorCode}의 구현체입니다.
+ *
+ * @author jack8
+ * @see ErrorCode
+ * @see ResponseCode
+ * @see com.studypals.global.exceptions.exception.GroupException GroupException
+ * @since 2025-04-02
+ */
+@Getter
+@RequiredArgsConstructor
+public enum GroupErrorCode implements ErrorCode {
+    // U02: User <-> Group 관련
+    GROUP_NOT_FOUND(ResponseCode.GROUP_SEARCH, HttpStatus.NOT_FOUND, "can't find group"),
+    GROUP_USER_NOT_FOUND(ResponseCode.GROUP_USER_LIST, HttpStatus.NOT_FOUND, "can't find user in group"),
+    GROUP_CREATE_FAIL(ResponseCode.GROUP_CREATE, HttpStatus.BAD_REQUEST, "failed to create group"),
+    GROUP_DELETE_FAIL(ResponseCode.GROUP_DELETE, HttpStatus.BAD_REQUEST, "failed to delete group"),
+    GROUP_UPDATE_FAIL(ResponseCode.GROUP_UPDATE, HttpStatus.BAD_REQUEST, "failed to update group"),
+    GROUP_JOIN_FAIL(ResponseCode.GROUP_JOIN, HttpStatus.BAD_REQUEST, "failed to join group"),
+    GROUP_LEAVE_FAIL(ResponseCode.GROUP_LEAVE, HttpStatus.BAD_REQUEST, "failed to leave group"),
+    GROUP_KICK_FAIL(ResponseCode.GROUP_KICK, HttpStatus.BAD_REQUEST, "failed to kick user from group"),
+    GROUP_INVITE_FAIL(ResponseCode.GROUP_INVITE, HttpStatus.BAD_REQUEST, "failed to invite user to group");
+
+
+    private final ResponseCode responseCode;
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return responseCode.getCode();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/errorCode/StudyErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/StudyErrorCode.java
@@ -1,0 +1,57 @@
+package com.studypals.global.exceptions.errorCode;
+
+import com.studypals.global.responses.ResponseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 공부 시간 도메인에서 발생하는 예외에 대한 상수 값을 정의합니다.
+ * <p>
+ * 상황에 대한 코드, 클라이언트로의 응답 코드 및 메시지를 가지며, 그 명명 규칙은 문서를 참조해야 합니다.
+ * 해당{@code StudyErrorCode} 는 {@link com.studypals.global.exceptions.exception.StudyException StudyException} 에서 사용되며 <br>
+ * {@code NAME(ResponseCode, HttpStatus.STATUS, "some message")}로 저장됩니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link ErrorCode}의 구현체입니다.
+ *
+ * @author jack8
+ * @see ErrorCode
+ * @see ResponseCode
+ * @see com.studypals.global.exceptions.exception.StudyException StudyException
+ * @since 2025-04-02
+ */
+@Getter
+@RequiredArgsConstructor
+public enum StudyErrorCode implements ErrorCode {
+
+    STUDY_TIME_NOT_FOUND(ResponseCode.STUDY_TIME_ALL, HttpStatus.NOT_FOUND, "can't find study time"),
+    STUDY_TIME_PARTIAL_FAIL(ResponseCode.STUDY_TIME_PARTIAL, HttpStatus.BAD_REQUEST, "failed to get partial study time"),
+    STUDY_TIME_RESET_FAIL(ResponseCode.STUDY_TIME_RESET, HttpStatus.BAD_REQUEST, "failed to reset study time"),
+    STUDY_TIME_ADD_FAIL(ResponseCode.STUDY_TIME_ADD, HttpStatus.BAD_REQUEST, "failed to add study time"),
+    STUDY_TIME_DELETE_FAIL(ResponseCode.STUDY_TIME_DELETE, HttpStatus.BAD_REQUEST, "failed to delete study time"),
+    STUDY_CATEGORY_NOT_FOUND(ResponseCode.STUDY_CATEGORY_LIST, HttpStatus.NOT_FOUND, "can't find study category"),
+    STUDY_CATEGORY_ADD_FAIL(ResponseCode.STUDY_CATEGORY_ADD, HttpStatus.BAD_REQUEST, "failed to add study category"),
+    STUDY_CATEGORY_DELETE_FAIL(ResponseCode.STUDY_CATEGORY_DELETE, HttpStatus.BAD_REQUEST, "failed to delete study category"),
+    STUDY_CATEGORY_UPDATE_FAIL(ResponseCode.STUDY_CATEGORY_UPDATE, HttpStatus.BAD_REQUEST, "failed to update study category");
+
+
+    private final ResponseCode responseCode;
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return responseCode.getCode();
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/errorCode/StudyErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/StudyErrorCode.java
@@ -1,7 +1,6 @@
 package com.studypals.global.exceptions.errorCode;
 
 import com.studypals.global.responses.ResponseCode;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
  * @see com.studypals.global.exceptions.exception.StudyException StudyException
  * @since 2025-04-02
  */
-@Getter
 @RequiredArgsConstructor
 public enum StudyErrorCode implements ErrorCode {
 

--- a/src/main/java/com/studypals/global/exceptions/exception/AuthException.java
+++ b/src/main/java/com/studypals/global/exceptions/exception/AuthException.java
@@ -1,0 +1,33 @@
+package com.studypals.global.exceptions.exception;
+
+import com.studypals.global.exceptions.BaseException;
+import com.studypals.global.exceptions.errorCode.AuthErrorCode;
+
+/**
+ * 인증 / 인가 및 멤버 관리에서 발생하는 예외입니다.
+ * <p>
+ * {@link AuthErrorCode} 의 값과 (optional) 내부 로그 메시지를 담습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link BaseException} 의 구현 클래스입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code AuthException(AuthErrorCode errorCode)}  <br>
+ * AuthErrorCode만 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담지 않는 예외를 생성합니다. <br>
+ * {@code AuthException(AuthErrorCode errorCode, String logMessage)}  <br>
+ * AuthErrorCode만 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ *
+ * @author jack8
+ * @see AuthErrorCode
+ * @see BaseException
+ * @since 2025-03-31
+ */
+public class AuthException extends BaseException {
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthException(AuthErrorCode errorCode, String logMessage) {
+        super(errorCode, logMessage);
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/exception/AuthException.java
+++ b/src/main/java/com/studypals/global/exceptions/exception/AuthException.java
@@ -14,8 +14,10 @@ import com.studypals.global.exceptions.errorCode.AuthErrorCode;
  * <p><b>주요 생성자:</b><br>
  * {@code AuthException(AuthErrorCode errorCode)}  <br>
  * AuthErrorCode만 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담지 않는 예외를 생성합니다. <br>
- * {@code AuthException(AuthErrorCode errorCode, String logMessage)}  <br>
+ * {@code AuthException(AuthErrorCode errorCode, String clientMessage)}  <br>
  * AuthErrorCode만 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ * {@code AuthException(AuthErrorCode errorCode, String clientMessage, String logMessage)}  <br>
+ * AuthErrorCode만 매개변수로 받도록 강제합니다. 클라이언트로의 메시지 및 내부 로그 메시지를 담는 예외를 생성합니다. <br>
  *
  * @author jack8
  * @see AuthErrorCode
@@ -29,5 +31,9 @@ public class AuthException extends BaseException {
 
     public AuthException(AuthErrorCode errorCode, String logMessage) {
         super(errorCode, logMessage);
+    }
+
+    public AuthException(AuthErrorCode errorCode, String clientMessage, String logMessage) {
+        super(errorCode, clientMessage, logMessage);
     }
 }

--- a/src/main/java/com/studypals/global/exceptions/exception/AuthException.java
+++ b/src/main/java/com/studypals/global/exceptions/exception/AuthException.java
@@ -1,6 +1,5 @@
 package com.studypals.global.exceptions.exception;
 
-import com.studypals.global.exceptions.BaseException;
 import com.studypals.global.exceptions.errorCode.AuthErrorCode;
 
 /**

--- a/src/main/java/com/studypals/global/exceptions/exception/BaseException.java
+++ b/src/main/java/com/studypals/global/exceptions/exception/BaseException.java
@@ -1,6 +1,7 @@
-package com.studypals.global.exceptions;
+package com.studypals.global.exceptions.exception;
 
 import com.studypals.global.exceptions.errorCode.ErrorCode;
+import lombok.Getter;
 
 /**
  * 모든 커스텀 예외 클래스의 추상 부모 클래스입니다. 자체적으로는 사용되지 않습니다.
@@ -22,6 +23,7 @@ import com.studypals.global.exceptions.errorCode.ErrorCode;
  * @see ErrorCode
  * @since 2025-03-31
  */
+@Getter
 public abstract class BaseException extends RuntimeException {
     private final ErrorCode errorCode;
     private final String logMessage;

--- a/src/main/java/com/studypals/global/exceptions/exception/GroupException.java
+++ b/src/main/java/com/studypals/global/exceptions/exception/GroupException.java
@@ -1,0 +1,38 @@
+package com.studypals.global.exceptions.exception;
+
+import com.studypals.global.exceptions.errorCode.ErrorCode;
+
+/**
+ * 그룹 관리에서 발생하는 예외입니다.
+ * <p>
+ * {@link com.studypals.global.exceptions.errorCode.GroupErrorCode GroupErrorCode} 의 값과 (optional) 내부 로그 메시지를 담습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link BaseException} 의 구현 클래스입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code GroupException(GroupErrorCode errorCode)}  <br>
+ * GroupErrorCode 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담지 않는 예외를 생성합니다. <br>
+ * {@code GroupException(GroupErrorCode errorCode, String clientMessage)}  <br>
+ * GroupErrorCode 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ * {@code GroupException(GroupErrorCode errorCode, String clientMessage, String logMessage)}  <br>
+ * GroupErrorCode 매개변수로 받도록 강제합니다. 클라이언트로의 메시지 및 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ *
+ * @author jack8
+ * @see com.studypals.global.exceptions.errorCode.GroupErrorCode GroupErrorCode
+ * @see BaseException
+ * @since 2025-04-02
+ */
+public class GroupException extends BaseException {
+    protected GroupException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    protected GroupException(ErrorCode errorCode, String logMessage) {
+        super(errorCode, logMessage);
+    }
+
+    protected GroupException(ErrorCode errorCode, String clientMessage, String logMessage) {
+        super(errorCode, clientMessage, logMessage);
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/exception/StudyException.java
+++ b/src/main/java/com/studypals/global/exceptions/exception/StudyException.java
@@ -1,0 +1,38 @@
+package com.studypals.global.exceptions.exception;
+
+import com.studypals.global.exceptions.errorCode.ErrorCode;
+
+/**
+ * 공부 도메인에서 발생하는 예외입니다.
+ * <p>
+ * {@link com.studypals.global.exceptions.errorCode.StudyErrorCode StudyErrorCode} 의 값과 (optional) 내부 로그 메시지를 담습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link BaseException} 의 구현 클래스입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code StudyException(StudyErrorCode errorCode)}  <br>
+ * GroupErrorCode 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담지 않는 예외를 생성합니다. <br>
+ * {@code StudyException(StudyErrorCode errorCode, String clientMessage)}  <br>
+ * StudyErrorCode 매개변수로 받도록 강제합니다. 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ * {@code StudyException(StudyErrorCode errorCode, String clientMessage, String logMessage)}  <br>
+ * StudyErrorCode 매개변수로 받도록 강제합니다. 클라이언트로의 메시지 및 내부 로그 메시지를 담는 예외를 생성합니다. <br>
+ *
+ * @author jack8
+ * @see com.studypals.global.exceptions.errorCode.StudyErrorCode StudyErrorCode
+ * @see BaseException
+ * @since 2025-04-02
+ */
+public class StudyException extends BaseException {
+    protected StudyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    protected StudyException(ErrorCode errorCode, String logMessage) {
+        super(errorCode, logMessage);
+    }
+
+    protected StudyException(ErrorCode errorCode, String clientMessage, String logMessage) {
+        super(errorCode, clientMessage, logMessage);
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/DefaultExceptionHandler.java
@@ -1,0 +1,207 @@
+package com.studypals.global.exceptions.exceptionHandler;
+
+import com.studypals.global.responses.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.ConversionNotSupportedException;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.validation.method.MethodValidationException;
+import org.springframework.web.ErrorResponseException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+/**
+ * 스프링에서 request 시 발생하는 예외에 대한 handler 입니다.
+ * <p>
+ * 여러 예외에 대하여, 이를 적절한 방식으로 가공하여 반환합니다. 다음과 같은 예외를 처리합니다.
+ * <pre>
+ * {@code
+ * HttpRequestMethodNotSupportedException
+ * HttpMediaTypeNotSupportedException
+ * HttpMediaTypeNotAcceptableException
+ * MissingPathVariableException
+ * MissingServletRequestParameterException
+ * MissingServletRequestPartException
+ * ServletRequestBindingException
+ * NoHandlerFoundException
+ * NoResourceFoundException
+ * HttpMessageNotReadableException
+ * TypeMismatchException
+ * MethodArgumentNotValidException
+ * HandlerMethodValidationException
+ * MethodValidationException
+ * HttpMessageNotWritableException
+ * ConversionNotSupportedException
+ * ErrorResponseException
+ * AsyncRequestNotUsableException
+ * AsyncRequestTimeoutException
+ * MaxUploadSizeExceededException
+ * } </pre>
+ * <p><b>상속 정보:</b><br>
+ * ResponseEntityExceptionHandler 추상 클래스의 구체 클래스입니다.
+ *
+ * @author jack8
+ * @see ResponseEntityExceptionHandler
+ * @see ExceptionHandlerOrder
+ * @since 2025-04-01
+ */
+
+@Slf4j
+@RestControllerAdvice
+@Order(ExceptionHandlerOrder.DEFAULT_EXCEPTION_HANDLER)
+public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private ResponseEntity<Object> fail(String code, String message, HttpStatus status) {
+        return ResponseEntity.status(status).body(CommonResponse.fail(code, message));
+    }
+
+    // ERE - 요청 형식 오류
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(HttpRequestMethodNotSupportedException ex,
+                                                                         HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-00", "Unsupported HTTP method", HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(HttpMediaTypeNotSupportedException ex,
+                                                                     HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-01", "Unsupported media type", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(HttpMediaTypeNotAcceptableException ex,
+                                                                      HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-02", "Not acceptable media type", HttpStatus.NOT_ACCEPTABLE);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingPathVariable(MissingPathVariableException ex,
+                                                               HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-03", "Missing path variable", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestParameter(MissingServletRequestParameterException ex,
+                                                                          HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-04", "Missing request parameter", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMissingServletRequestPart(MissingServletRequestPartException ex,
+                                                                     HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-05", "Missing request part", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleServletRequestBindingException(ServletRequestBindingException ex,
+                                                                          HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-06", "Request binding failed", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleNoHandlerFoundException(NoHandlerFoundException ex,
+                                                                   HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-07", "No handler found for URL", HttpStatus.NOT_FOUND);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleNoResourceFoundException(NoResourceFoundException ex,
+                                                                    HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-08", "Resource not found", HttpStatus.NOT_FOUND);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-09", "Malformed JSON request", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleTypeMismatch(TypeMismatchException ex,
+                                                        HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("ERE-10", "Parameter type mismatch", HttpStatus.BAD_REQUEST);
+    }
+
+    // EVD - 검증 실패
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(err -> err.getField() + ": " + err.getDefaultMessage())
+                .findFirst()
+                .orElse("Validation failed");
+        return fail("EVD-00", message, HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException ex,
+                                                                            HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("EVD-01", "Method parameter validation failed", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodValidationException(MethodValidationException ex,
+                                                                     HttpHeaders headers, HttpStatus status, WebRequest request) {
+        return fail("EVD-02", "Method-level validation failed", HttpStatus.BAD_REQUEST);
+    }
+
+    // EIS - 서버 내부 오류
+    @Override
+    protected ResponseEntity<Object> handleHttpMessageNotWritable(HttpMessageNotWritableException ex,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("EIS-00", "Failed to write JSON response", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleConversionNotSupported(ConversionNotSupportedException ex,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("EIS-01", "Conversion not supported", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleErrorResponseException(ErrorResponseException ex,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("EIS-02", "Unhandled error occurred", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // EAS - 비동기 오류
+    @Override
+    protected ResponseEntity<Object> handleAsyncRequestNotUsableException(AsyncRequestNotUsableException ex,
+                                                                          WebRequest request) {
+        return fail("EAS-00", "Async request not usable", HttpStatus.BAD_REQUEST);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleAsyncRequestTimeoutException(AsyncRequestTimeoutException ex,
+                                                                        HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("EAS-01", "Async request timeout", HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    // EFU - 파일 업로드 실패
+    @Override
+    protected ResponseEntity<Object> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex,
+                                                                          HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        return fail("EFU-00", "File size exceeds limit", HttpStatus.PAYLOAD_TOO_LARGE);
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/ExceptionHandlerOrder.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/ExceptionHandlerOrder.java
@@ -1,0 +1,14 @@
+package com.studypals.global.exceptions.exceptionHandler;
+
+/**
+ * exception handler 의 처리 순서에 대한 상수 값을 정의하고 관리하는 객체입니다.
+ * <p>
+ * public 한 static final 내부 필드를 통해 값을 관리합니다.
+ *
+ * @author jack8
+ * @since 2025-04-01
+ */
+public class ExceptionHandlerOrder {
+    public static final int DEFAULT_EXCEPTION_HANDLER = 1;
+    public static final int GLOBAL_EXCEPTION_HANDLER = 2;
+}

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.studypals.global.exceptions.exceptionHandler;
 
+import com.studypals.global.exceptions.errorCode.ErrorCode;
 import com.studypals.global.exceptions.exception.BaseException;
 import com.studypals.global.responses.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(CommonResponse.fail(code, message));
     }
 
+    private ResponseEntity<Object> fail(ErrorCode code, String message, HttpStatus status) {
+        return fail(code.getCode(), message, status);
+    }
+
     @Value("${debug.message.print:false}")
     private boolean isDebug;
 
@@ -49,7 +54,7 @@ public class GlobalExceptionHandler {
         if(isDebug) {
             log.warn("{}", ex.getLogMessage());
         }
-        return fail(ex.getErrorCode().getCode(), ex.getMessage(), ex.getErrorCode().getHttpStatus());
+        return fail(ex.getErrorCode(), ex.getMessage(), ex.getErrorCode().getHttpStatus());
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandler.java
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<Object> handleBaseException(BaseException ex) {
-        if(isDebug) {
+        if (isDebug) {
             log.warn("{}", ex.getLogMessage());
         }
         return fail(ex.getErrorCode(), ex.getMessage(), ex.getErrorCode().getHttpStatus());

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.studypals.global.exceptions.exceptionHandler;
+
+import com.studypals.global.exceptions.exception.BaseException;
+import com.studypals.global.responses.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * custom exception에 대한 exception handler 입니다.
+ * <p>
+ * {@link ExceptionHandlerOrder}에 정의된 바에 따라 비교적 후순위로 처리됩니다. 내부 필드 isDebug를 통해
+ * 내부 메시지의 표시 여부를 결정합니다.
+ * 모든 응답은 {@link CommonResponse} 를 통해 이루어집니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 상속 정보를 적습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * 존재하지 않습니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * 로그 표시를 위한 {@code Slf4j}를 사용합니다.(lombok)
+ *
+ * @author jack8
+ * @see ExceptionHandlerOrder
+ * @see BaseException
+ * @since 2025-04-01
+ */
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+@Order(ExceptionHandlerOrder.GLOBAL_EXCEPTION_HANDLER)
+public class GlobalExceptionHandler {
+
+    @Value("${debug.message.print:false}")
+    private boolean isDebug;
+
+    @ExceptionHandler(BaseException.class)
+    public CommonResponse<Void> handleBaseException(BaseException ex) {
+        if(isDebug) {
+            log.warn("{}", ex.getLogMessage());
+        }
+        return CommonResponse.fail(ex.getErrorCode().getCode(), ex.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public CommonResponse<Void> handleUnexpectedException(Exception ex) {
+        log.error("[unexpected] {}", ex.getMessage(), ex);
+        return CommonResponse.fail("INTERNAL-500", "unknown internal server error.");
+    }
+}

--- a/src/main/java/com/studypals/global/responses/CommonResponse.java
+++ b/src/main/java/com/studypals/global/responses/CommonResponse.java
@@ -11,17 +11,18 @@ import lombok.Getter;
  * {@code CommonResponse<Example> response = CommonResponse.fail("ERE-00", "message");} <br>
  *
  * <p><b>상속 정보:</b><br>
- * 존재하지 않으나, 이후 다른 response 타입이 생길 경우, 이의 부모 클래스가 될 수 있습니다.
+ * {@link Response} 의 구현 클래스입니다.
  *
  * <p><b>주요 생성자:</b><br>
  * 생성자는 private으로 선언되었으며, static 메서드를 통하여 인스턴스가 생성됩니다. <br>
  *
  *
  * @author jack8
+ * @see Response
  * @since 2025-04-01
  */
 @Getter
-public class CommonResponse<T> {
+public class CommonResponse<T> implements Response<T> {
     private final String code;
     private final String status;
     private final T data;

--- a/src/main/java/com/studypals/global/responses/CommonResponse.java
+++ b/src/main/java/com/studypals/global/responses/CommonResponse.java
@@ -1,0 +1,54 @@
+package com.studypals.global.responses;
+
+import lombok.Getter;
+
+/**
+ * 응답 형식에 대한 템플릿입니다. 도메인 및 기능 코드/상태/데이터/메시지가 포함되어 있습니다.
+ * <p>
+ * factory method 패턴을 사용하여 다음과 같이 작성할 수 있습니다. <br>
+ * {@code CommonResponse<Example> response = CommonResponse.success("U10-300", example, "message);} <br>
+ * 혹은 <br>
+ * {@code CommonResponse<Example> response = CommonResponse.fail("U10-300", example, "message");} <br>
+ *
+ * <p><b>상속 정보:</b><br>
+ * 존재하지 않으나, 이후 다른 response 타입이 생길 경우, 이의 부모 클래스가 될 수 있습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * 생성자는 private으로 선언되었으며, static 메서드를 통하여 인스턴스가 생성됩니다. <br>
+ *
+ *
+ * @author jack8
+ * @since 2025-04-01
+ */
+@Getter
+public class CommonResponse<T> {
+    private final String code;
+    private final String status;
+    private final T data;
+    private final String message;
+
+    private CommonResponse(String code, String status, T data, String message) {
+        this.code = code;
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> CommonResponse<T> success(String code, T data, String message) {
+        return new CommonResponse<>(code, "success", data, message);
+    }
+
+    public static <T> CommonResponse<T> success(String code, T data) {
+        return new CommonResponse<>(code, "success", data, "success to response");
+    }
+
+    public static <T> CommonResponse<T> success(String code) {
+        return new CommonResponse<>(code, "success", null, "success to response");
+    }
+
+    public static <T> CommonResponse<T> fail(String code, String message) {
+        return new CommonResponse<>(code, "fail", null, message);
+    }
+
+
+}

--- a/src/main/java/com/studypals/global/responses/CommonResponse.java
+++ b/src/main/java/com/studypals/global/responses/CommonResponse.java
@@ -6,9 +6,9 @@ import lombok.Getter;
  * 응답 형식에 대한 템플릿입니다. 도메인 및 기능 코드/상태/데이터/메시지가 포함되어 있습니다.
  * <p>
  * factory method 패턴을 사용하여 다음과 같이 작성할 수 있습니다. <br>
- * {@code CommonResponse<Example> response = CommonResponse.success("U10-300", example, "message);} <br>
+ * {@code CommonResponse<Example> response = CommonResponse.success(ResponseCode.SEARCH_USER, example, "message);} <br>
  * 혹은 <br>
- * {@code CommonResponse<Example> response = CommonResponse.fail("U10-300", example, "message");} <br>
+ * {@code CommonResponse<Example> response = CommonResponse.fail("ERE-00", "message");} <br>
  *
  * <p><b>상속 정보:</b><br>
  * 존재하지 않으나, 이후 다른 response 타입이 생길 경우, 이의 부모 클래스가 될 수 있습니다.
@@ -27,6 +27,13 @@ public class CommonResponse<T> {
     private final T data;
     private final String message;
 
+    private CommonResponse(ResponseCode code, String status, T data, String message) {
+        this.code = code.getCode();
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
     private CommonResponse(String code, String status, T data, String message) {
         this.code = code;
         this.status = status;
@@ -34,16 +41,20 @@ public class CommonResponse<T> {
         this.message = message;
     }
 
-    public static <T> CommonResponse<T> success(String code, T data, String message) {
+    public static <T> CommonResponse<T> success(ResponseCode code, T data, String message) {
         return new CommonResponse<>(code, "success", data, message);
     }
 
-    public static <T> CommonResponse<T> success(String code, T data) {
+    public static <T> CommonResponse<T> success(ResponseCode code, T data) {
         return new CommonResponse<>(code, "success", data, "success to response");
     }
 
-    public static <T> CommonResponse<T> success(String code) {
+    public static <T> CommonResponse<T> success(ResponseCode code) {
         return new CommonResponse<>(code, "success", null, "success to response");
+    }
+
+    public static <T> CommonResponse<T> fail(ResponseCode code, String message) {
+        return new CommonResponse<>(code, "fail", null, message);
     }
 
     public static <T> CommonResponse<T> fail(String code, String message) {

--- a/src/main/java/com/studypals/global/responses/Response.java
+++ b/src/main/java/com/studypals/global/responses/Response.java
@@ -1,0 +1,16 @@
+package com.studypals.global.responses;
+
+/**
+ * 응답 객체에 대한 정의 인터페이스입니다.
+ * <p>
+ * getCode, getStatus, getMessage 에 대한 정의를 강제합니다.
+ *
+ * @author jack8
+ * @since 2025-04-02
+ */
+public interface Response<T> {
+    String getCode();
+    String getStatus();
+    T getData();
+    String getMessage();
+}

--- a/src/main/java/com/studypals/global/responses/ResponseCode.java
+++ b/src/main/java/com/studypals/global/responses/ResponseCode.java
@@ -1,0 +1,52 @@
+package com.studypals.global.responses;
+
+import lombok.Getter;
+
+/**
+ * 응답 코드에 대한 값을 정의하고, 이를 관리합니다.
+ * <p>
+ * enum을 통해 관리하며, 도메인 로직에서 발생하는 기능 코드들을 정의하고, 이를 관리합니다. 옳바른 응답 및
+ * 예외에서 사용됩니다.
+ *
+ * @author jack8
+ * @since 2025-04-02
+ */
+@Getter
+public enum ResponseCode {
+    // U01 - User
+    USER_SEARCH("U01-00"),
+    USER_CREATE("U01-01"),
+    USER_UPDATE("U01-02"),
+    USER_DELETE("U01-03"),
+    USER_SIGNUP("U01-04"),
+    USER_LOGIN("U01-05"),
+    USER_AUTH_CHECK("U01-06"),
+
+    // U02 - User & Group
+    GROUP_SEARCH("U02-00"),
+    GROUP_USER_LIST("U02-01"),
+    GROUP_CREATE("U02-02"),
+    GROUP_DELETE("U02-03"),
+    GROUP_UPDATE("U02-04"),
+    GROUP_JOIN("U02-05"),
+    GROUP_LEAVE("U02-06"),
+    GROUP_KICK("U02-07"),
+    GROUP_INVITE("U02-08"),
+
+    // U03 - User Study & Time
+    STUDY_TIME_ALL("U03-00"),
+    STUDY_TIME_PARTIAL("U03-01"),
+    STUDY_TIME_RESET("U03-02"),
+    STUDY_TIME_ADD("U03-03"),
+    STUDY_TIME_DELETE("U03-04"),
+    STUDY_CATEGORY_LIST("U03-05"),
+    STUDY_CATEGORY_ADD("U03-06"),
+    STUDY_CATEGORY_DELETE("U03-07"),
+    STUDY_CATEGORY_UPDATE("U03-08");
+
+    private final String code;
+
+    ResponseCode(String code) {
+        this.code = code;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=studyPals
+
+
+debug.message.print = true

--- a/src/test/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandlerTest.java
@@ -1,0 +1,53 @@
+package com.studypals.global.exceptions.exceptionHandler;
+
+import com.studypals.testModules.testComponent.TestController;
+import com.studypals.testModules.testComponent.TestErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import static com.studypals.testModules.testUtils.JsonFieldResultMatcher.hasKey;
+import static com.studypals.testModules.testUtils.JsonFieldResultMatcher.hasStatus;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * {@link GlobalExceptionHandler} 에 대한 테스트. 일부 테스트 유틸리티를 사용하여진행하였다.
+ *
+ * @author jack8
+ * @see GlobalExceptionHandler
+ * @since 2025-04-01
+ */
+
+@WebMvcTest(TestController.class)
+@Import(GlobalExceptionHandler.class)
+@TestPropertySource(properties = "debug.message.print=false")
+class GlobalExceptionHandlerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("custom exception이 발생하여 CommonResponse로 매핑되어 응답")
+    void handleBaseException() throws Exception {
+        mockMvc.perform(get("/test/base"))
+                .andExpect(hasStatus(TestErrorCode.TEST_ERROR_CODE))
+                .andExpect(hasKey(TestErrorCode.TEST_ERROR_CODE));
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외가 발생")
+    void handleUnexpectedException() throws Exception {
+        mockMvc.perform(get("/test/unexpected"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("EIS-02"))
+                .andExpect(jsonPath("$.message").value("unknown internal server error"));
+    }
+
+
+
+
+}

--- a/src/test/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/studypals/global/exceptions/exceptionHandler/GlobalExceptionHandlerTest.java
@@ -43,8 +43,9 @@ class GlobalExceptionHandlerTest {
     void handleUnexpectedException() throws Exception {
         mockMvc.perform(get("/test/unexpected"))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.code").value("EIS-02"))
-                .andExpect(jsonPath("$.message").value("unknown internal server error"));
+                .andExpect(hasKey("code", "EIS-02"))
+                .andExpect(hasKey("message", "unknown internal server error"));
+
     }
 
 

--- a/src/test/java/com/studypals/testModules/testComponent/TestController.java
+++ b/src/test/java/com/studypals/testModules/testComponent/TestController.java
@@ -1,0 +1,26 @@
+package com.studypals.testModules.testComponent;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 테스트 시 사용할 controller 메서드 집합
+ *
+ * @author jack8
+ * @since 2025-04-01
+ */
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    @GetMapping("/base")
+    public void throwBaseException() {
+        throw new TestException();
+    }
+
+    @GetMapping("/unexpected")
+    public void throwUnexpectedException() {
+        throw new RuntimeException("예상 못한 예외");
+    }
+}

--- a/src/test/java/com/studypals/testModules/testComponent/TestErrorCode.java
+++ b/src/test/java/com/studypals/testModules/testComponent/TestErrorCode.java
@@ -1,0 +1,35 @@
+package com.studypals.testModules.testComponent;
+
+import com.studypals.global.exceptions.errorCode.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 테스트 시 사용할 ErrorCode. 다음과 같은 값을 가지고 있다.
+ * <pre>
+ *     code : "TEST-400"
+ *     httpStatus : 400(BAD REQUEST)
+ *     message : "test message"
+ * </pre>
+ *
+ * @author jack8
+ * @since 2025-04-01
+ */
+public enum TestErrorCode implements ErrorCode {
+    TEST_ERROR_CODE
+    ;
+
+    @Override
+    public String getCode() {
+        return "TEST-400";
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return "test message";
+    }
+}

--- a/src/test/java/com/studypals/testModules/testComponent/TestException.java
+++ b/src/test/java/com/studypals/testModules/testComponent/TestException.java
@@ -1,0 +1,20 @@
+package com.studypals.testModules.testComponent;
+
+import com.studypals.global.exceptions.exception.BaseException;
+
+/**
+ * 테스트 시 사용할 exception. 다음과 같은 값을 가지고 있다.
+ * <pre>
+ *     errorCode : TestErrorCode.TEST_ERROR_CODE
+ *     log message : "log message"
+ *     client message : default
+ * </pre>
+ *
+ * @author jack8
+ * @since 2025-04-01
+ */
+public class TestException extends BaseException {
+    public TestException() {
+        super(TestErrorCode.TEST_ERROR_CODE, "log message");
+    }
+}

--- a/src/test/java/com/studypals/testModules/testUtils/JsonFieldResultMatcher.java
+++ b/src/test/java/com/studypals/testModules/testUtils/JsonFieldResultMatcher.java
@@ -1,0 +1,183 @@
+package com.studypals.testModules.testUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.studypals.global.exceptions.errorCode.ErrorCode;
+import org.junit.jupiter.api.Assertions;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ResultMatcher에 대한 구현 클래스. discussion 및 노션 참조 필요
+ *
+ * @author jack8
+ * @since 2025-04-01
+ */
+public class JsonFieldResultMatcher implements ResultMatcher {
+    private final List<ResultMatcher> matchers;
+
+    public JsonFieldResultMatcher(List<ResultMatcher> matchers) {
+        this.matchers = matchers;
+    }
+
+    @Override
+    public void match(MvcResult result) throws Exception {
+        for (ResultMatcher matcher : matchers) {
+            matcher.match(result);
+        }
+    }
+
+    public static ResultMatcher hasStatus(ErrorCode errorCode) {
+        return result -> {
+            HttpStatus expectedStatus = errorCode.getHttpStatus();
+            int actualStatus = result.getResponse().getStatus();
+            Assertions.assertEquals(expectedStatus.value(), actualStatus,
+                    "Expected status code " + expectedStatus.value() + " but got " + actualStatus);
+        };
+    }
+
+    public static ResultMatcher hasKey(String key, String value) {
+        List<ResultMatcher> matchers = new ArrayList<>();
+        matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
+        return new JsonFieldResultMatcher(matchers);
+    }
+
+    public static ResultMatcher hasKey(String outputString) {
+        return result -> Assertions.assertEquals(outputString, result.getResponse().getContentAsString());
+    }
+
+    public static ResultMatcher hasKey(ErrorCode errorCode) {
+        List<ResultMatcher> matchers = new ArrayList<>();
+        matchers.add(MockMvcResultMatchers.jsonPath("$.code").value(errorCode.getCode()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.status").value("fail"));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.message").value(errorCode.getMessage()));
+        return new JsonFieldResultMatcher(matchers);
+    }
+
+    public static ResultMatcher hasKey(Object dto) {
+        List<ResultMatcher> matchers = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.findAndRegisterModules();
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = mapper.convertValue(dto, Map.class);
+
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            if (value != null) {
+                if (value instanceof String) {
+                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
+                } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean) {
+                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
+                } else if (value instanceof LocalDate) {
+                    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+                    String formattedDate = ((LocalDate) value).format(formatter);
+                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(formattedDate));
+                } else if (value instanceof LocalDateTime) {
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                    String formattedDateTime = ((LocalDateTime) value).truncatedTo(ChronoUnit.SECONDS).format(formatter);
+                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(formattedDateTime));
+                } else {
+                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
+                }
+            }
+        }
+
+        return new JsonFieldResultMatcher(matchers);
+    }
+
+    public static ResultMatcher hasKey(List<?> dtos) {
+        ObjectMapper mapper = new ObjectMapper();
+        List<ResultMatcher> matchers = new ArrayList<>();
+
+        // 리스트의 크기를 검증합니다.
+        matchers.add(MockMvcResultMatchers.jsonPath("$.length()").value(dtos.size()));
+
+        for (int i = 0; i < dtos.size(); i++) {
+            Object dto = dtos.get(i);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = mapper.convertValue(dto, Map.class);
+
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                Object value = entry.getValue();
+
+                if (value != null) {
+                    if (value instanceof LocalDate) {
+                        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+                        String formattedDate = ((LocalDate) value).format(formatter);
+                        matchers.add(MockMvcResultMatchers.jsonPath("$[" + i + "]." + entry.getKey()).value(formattedDate));
+                    } else if (value instanceof LocalDateTime) {
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                        String formattedDateTime = ((LocalDateTime) value).truncatedTo(ChronoUnit.SECONDS).format(formatter);
+                        matchers.add(MockMvcResultMatchers.jsonPath("$[" + i + "]." + entry.getKey()).value(formattedDateTime));
+                    } else {
+                        matchers.add(MockMvcResultMatchers.jsonPath("$[" + i + "]." + entry.getKey()).value(value));
+                    }
+                }
+            }
+        }
+
+        return new JsonFieldResultMatcher(matchers);
+    }
+
+    public static ResultMatcher hasKey(Page<?> page) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        List<ResultMatcher> matchers = new ArrayList<>();
+
+        matchers.add(MockMvcResultMatchers.jsonPath("$.totalElements").value(page.getTotalElements()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.totalPages").value(page.getTotalPages()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.size").value(page.getSize()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.number").value(page.getNumber()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.numberOfElements").value(page.getNumberOfElements()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.first").value(page.isFirst()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.last").value(page.isLast()));
+        matchers.add(MockMvcResultMatchers.jsonPath("$.empty").value(page.isEmpty()));
+
+        List<?> content = page.getContent();
+        matchers.add(MockMvcResultMatchers.jsonPath("$.content.length()").value(content.size()));
+
+        for (int i = 0; i < content.size(); i++) {
+            Object dto = content.get(i);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = mapper.convertValue(dto, Map.class);
+
+            for (Map.Entry<String, Object> entry : map.entrySet()) {
+                Object value = entry.getValue();
+
+                if (value != null) {
+                    if (value instanceof LocalDate) {
+                        DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+                        String formattedDate = ((LocalDate) value).format(formatter);
+                        matchers.add(MockMvcResultMatchers.jsonPath("$.content[" + i + "]." + entry.getKey()).value(formattedDate));
+                    } else if (value instanceof LocalDateTime) {
+                        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                        String formattedDateTime = ((LocalDateTime) value).truncatedTo(ChronoUnit.SECONDS).format(formatter);
+                        matchers.add(MockMvcResultMatchers.jsonPath("$.content[" + i + "]." + entry.getKey()).value(formattedDateTime));
+                    } else {
+                        matchers.add(MockMvcResultMatchers.jsonPath("$.content[" + i + "]." + entry.getKey()).value(value));
+                    }
+                }
+            }
+        }
+
+        return new JsonFieldResultMatcher(matchers);
+    }
+
+}

--- a/src/test/java/com/studypals/testModules/testUtils/JsonFieldResultMatcher.java
+++ b/src/test/java/com/studypals/testModules/testUtils/JsonFieldResultMatcher.java
@@ -78,22 +78,19 @@ public class JsonFieldResultMatcher implements ResultMatcher {
             String key = entry.getKey();
             Object value = entry.getValue();
 
-            if (value != null) {
-                if (value instanceof String) {
-                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
-                } else if (value instanceof Integer || value instanceof Long || value instanceof Boolean) {
-                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
-                } else if (value instanceof LocalDate) {
-                    DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
-                    String formattedDate = ((LocalDate) value).format(formatter);
-                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(formattedDate));
-                } else if (value instanceof LocalDateTime) {
-                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
-                    String formattedDateTime = ((LocalDateTime) value).truncatedTo(ChronoUnit.SECONDS).format(formatter);
-                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(formattedDateTime));
-                } else {
-                    matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
-                }
+            if(value == null) continue;
+            if (value instanceof String || value instanceof Integer || value instanceof Long || value instanceof Boolean) {
+                matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
+            }  else if (value instanceof LocalDate) {
+                DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE;
+                String formattedDate = ((LocalDate) value).format(formatter);
+                matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(formattedDate));
+            } else if (value instanceof LocalDateTime) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+                String formattedDateTime = ((LocalDateTime) value).truncatedTo(ChronoUnit.SECONDS).format(formatter);
+                matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(formattedDateTime));
+            } else {
+                matchers.add(MockMvcResultMatchers.jsonPath("$." + key).value(value));
             }
         }
 


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->
[#4][FEATURE] custom exception 정의
<!-- Auto close 할 이슈 번호 -->
- close #4

## ✨ 구현 기능 명세
custom 예외 및 전역 예외 헨들러, 일부 자체적으로 발생하는 예외에 대한 헨들러를 작성하였습니다.
모든 예외는 `BaseException` 을 상속받으며, 내부의 값(기능 코드, 응답 코드, 메시지)는 `ErrorCode` 인터페이스를 상속받는 구현체에서 정의됨. 단, 기능 코드는 `ResponseCode` 에서 관리됩니다.

모든 응답은 `Response` 를 통해 생성되어야 하며 여기에는 `ResponseCode`, `status`, `message` 가 포함되어야 합니다.  단, 대부분의 응답은 `CommonResponse` 로 처리될 수 있으며 이는 `Response` 의 구현 클래스입니다. 
`CommonResponse` 는 success 및 fail static method를 통해 생성되며 추가적으로 객체의 직렬화를 통해 생성되는 data 필드가 존재합니다.

### 예외 정의
```java
AuthException ex = new AuthException(AuthErrorCode.UNKNOWN_USER, "this is message to client", "this is message for logging");
```

### 응답 정의
```java
Response response = CommonResponse.success(ResponseCode.SERACH_USER, userData, "success to search user");
```

---
### 예외 헨들러
예외 헨들러는 `DefaultExceptionHandler` 와 GlobalExceptionHandler` 가 존재하며, 전자는 custom exception이 아닌 예외에 대한 처리를 담당하고, 후자는 custom exception의 처리를 담당합니다. 후자의 경우, isDebug 값을 통하여 로그 메시지 표시 여부를 결정할 수 있습니다.

### 테스트
테스트는 GlobalExceptionHandler에 대하여 작성하였으며 `JsonFieldResultMatcher` 를 통해 간편화하였습니다. test에서 정의한 controller 및 errorCode, exception을 통해 테스트하였습니다.

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point
전체적인 부분의 리뷰가 필요합니다. 추후 개발 시 사용되기 때문에 그 원리에 대해 익숙해질 필요가 있다고 봅니다. 코드 및 상속 구조 등은 notion에 정리되어 있습니다.

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
