### PR TITLE
[#42][TEST] MinIO 업로드, 삭제 테스트

### DIFF
--- a/src/main/java/com/studypals/domain/common/fileManage/dao/AbstractFileRepository.java
+++ b/src/main/java/com/studypals/domain/common/fileManage/dao/AbstractFileRepository.java
@@ -48,7 +48,7 @@ public abstract class AbstractFileRepository {
      * @return 저장된 URL 주소
      */
     public String upload(MultipartFile file) {
-        if (isFileAcceptable(file)) {
+        if (!isFileAcceptable(file)) {
             throw new IllegalArgumentException("can't accept file.");
         }
 

--- a/src/test/java/com/studypals/domain/common/fileManage/dao/AbstractFileRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/common/fileManage/dao/AbstractFileRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.studypals.domain.common.fileManage.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import java.util.Objects;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.studypals.domain.common.fileManage.ObjectStorage;
+
+/**
+ * {@link AbstractFileRepository} 에 대한 테스트코드입니다.
+ *
+ * <p>성공 케이스 및 유효하지 않은 확장자 업로드 시 뱉는 예외에 대한 테스트입니다.
+ *
+ * @author s0o0bn
+ * @see AbstractFileRepository
+ * @since 2025-04-11
+ */
+@ExtendWith(MockitoExtension.class)
+public class AbstractFileRepositoryTest {
+    private static final String FILE_PATH = "/test-dir";
+
+    @Mock
+    private ObjectStorage objectStorage;
+
+    private AbstractFileRepository fileRepository;
+
+    @BeforeEach
+    void setUp() {
+        fileRepository = new AbstractFileRepository(objectStorage) {
+            @Override
+            public String generateDestination(String fileName) {
+                return FILE_PATH + "/" + fileName;
+            }
+
+            @Override
+            public boolean isFileAcceptable(MultipartFile file) {
+                return Objects.requireNonNull(file.getContentType()).startsWith("image");
+            }
+        };
+    }
+
+    @Test
+    void upload_success() {
+        // given
+        MultipartFile file =
+                new MockMultipartFile("file", "test_image.png", "image/png", "test image content".getBytes());
+        String expected = FILE_PATH + file.getOriginalFilename();
+        given(objectStorage.upload(any(), anyString())).willReturn(expected);
+
+        // when
+        String actual = fileRepository.upload(file);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void upload_fail_notAcceptableExtension() {
+        // given
+        MultipartFile file =
+                new MockMultipartFile("file", "test_image.txt", "text/plain", "test image content".getBytes());
+
+        // when & then
+        assertThatThrownBy(() -> fileRepository.upload(file)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void delete_success() {
+        // given
+        String destination = FILE_PATH + "/file name";
+        String url = "http://test.endpoint:9000/test-bucket" + destination;
+        given(objectStorage.parsePath(url)).willReturn(destination);
+
+        // when
+        fileRepository.delete(url);
+
+        // then
+        then(objectStorage).should(times(1)).delete(destination);
+    }
+}

--- a/src/test/java/com/studypals/global/minio/MinioStorageTest.java
+++ b/src/test/java/com/studypals/global/minio/MinioStorageTest.java
@@ -1,0 +1,102 @@
+package com.studypals.global.minio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.minio.MinioClient;
+import io.minio.ObjectWriteResponse;
+import io.minio.RemoveObjectArgs;
+
+/**
+ * {@link MinioStorage} 에 대한 테스트코드입니다.
+ *
+ * <p>성공 케이스에 대한 테스트입니다.
+ *
+ * @author s0o0bn
+ * @see MinioStorage
+ * @since 2025-04-11
+ */
+@ExtendWith(MockitoExtension.class)
+public class MinioStorageTest {
+    private static final String TEST_ENDPOINT = "http://test.endpoint:9000";
+    private static final String TEST_BUCKET = "test-bucket";
+
+    @Mock
+    private MinioClient minioClient;
+
+    @InjectMocks
+    private MinioStorage minioStorage;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(minioStorage, "endpoint", TEST_ENDPOINT);
+        ReflectionTestUtils.setField(minioStorage, "bucket", TEST_BUCKET);
+    }
+
+    @Test
+    void upload_success() throws Exception {
+        // given
+        MultipartFile file =
+                new MockMultipartFile("file", "test_image.png", "image/png", "test image content".getBytes());
+        String destination = "file destination";
+        ObjectWriteResponse mockResponse = mock(ObjectWriteResponse.class);
+        given(minioClient.putObject(any())).willReturn(mockResponse);
+
+        // when
+        String actual = minioStorage.upload(file, destination);
+
+        // then
+        String expected = getStoragePath() + destination;
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void delete_success() throws Exception {
+        // given
+        String destination = "file destination";
+
+        // when
+        minioStorage.delete(destination);
+
+        // then
+        ArgumentCaptor<RemoveObjectArgs> captor = ArgumentCaptor.forClass(RemoveObjectArgs.class);
+        then(minioClient).should(times(1)).removeObject(captor.capture());
+
+        RemoveObjectArgs args = captor.getValue();
+        assertThat(args.bucket()).isEqualTo(TEST_BUCKET);
+        assertThat(args.object()).isEqualTo(destination);
+    }
+
+    @Test
+    void parsePath_success() {
+        // given
+        String destination = "file destination";
+        String url = getStoragePath() + destination;
+
+        // when
+        String actual = minioStorage.parsePath(url);
+
+        // then
+        String expected = "/" + destination;
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private String getStoragePath() {
+        return TEST_ENDPOINT + "/" + TEST_BUCKET + "/";
+    }
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #42 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

`MinioStorage`, `AbstractFileRepository`에 대한 테스트 코드 작성

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

기존 테스트 코드 작성해주신 부분에 따라, 유사한 스타일로 테스트 코드를 작성했습니다.
해당 방식으로 테스트를 쭉 작성하면 되는지 확인 부탁드립니다.

### `MinioStorage`

예외 케이스의 경우, 실제 인프라에서 발생하는 예외이기에 성공 케이스에 대한 테스트만 작성했습니다.
해당 클래스에서 `@Value`를 통해 주입 받는 필드값이 있어, `ReflectionTestUtils`를 통해 별도의 단위 테스트 전용 상수 값을 주입하도록 했습니다.

이전 테스트 경험에 기반해 작성한 부분인데, 보통 `void` 메서드에서 내부 메서드 호출 여부도 검증하는게 맞는지 궁금합니다. (line 78)

### `AbstractFileRepository`

테스트 대상이 추상클래스이나, 구현된 메서드가 있어 해당 부분 테스트 작성했습니다.
추상 클래스는 `@InjectMocks`를 사용할 수 없어 `@BeforeEach`로 임시 구현체를 생성해 사용했습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
