### PR TITLE
[#61][FEATURE] 그룹 가입 요청

### DIFF
--- a/src/asciidoc/api/group.adoc
+++ b/src/asciidoc/api/group.adoc
@@ -123,3 +123,51 @@ include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/qu
 
 include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/http-response.adoc[]
 include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/response-fields.adoc[]
+
+=== 그룹 가입 관련 API
+
+==== 1. 그룹 가입
+
+*Description* +
+
+'''
+
+초대 코드로 그룹에 가입합니다.
+해당 그룹이 가입 승인을 요구하지 않을 때만 가능합니다.
+
+*Request* +
+
+'''
+
+include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/http-request.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/request-fields.adoc[]
+
+*Response* +
+
+'''
+
+include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/http-response.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/response-headers.adoc[]
+
+==== 2. 그룹 가입 요청
+
+*Description* +
+
+'''
+
+초대 코드로 그룹에 가입을 요청합니다.
+해당 그룹이 가입 승인을 요구할 때만 가능합니다.
+
+*Request* +
+
+'''
+
+include::{snippets}/group-entry-controller-rest-docs-test/request-participant_success/http-request.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/request-participant_success/request-fields.adoc[]
+
+*Response* +
+
+'''
+
+include::{snippets}/group-entry-controller-rest-docs-test/request-participant_success/http-response.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/request-participant_success/response-headers.adoc[]

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -1,0 +1,28 @@
+package com.studypals.domain.groupManage.api;
+
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+import com.studypals.domain.groupManage.service.GroupEntryService;
+
+@RestController
+@RequestMapping("/groups")
+@RequiredArgsConstructor
+public class GroupEntryController {
+    private GroupEntryService groupEntryService;
+
+    @PostMapping("/{groupId}/join")
+    public ResponseEntity<Void> joinGroup(
+            @AuthenticationPrincipal Long userId, @PathVariable Long groupId, @RequestParam String entryCode) {
+        Long joinId = groupEntryService.joinGroup(userId, new GroupEntryInfo(groupId, entryCode));
+
+        return ResponseEntity.created(URI.create("/groups/" + groupId + "/members/" + joinId))
+                .build();
+    }
+}

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -11,6 +11,17 @@ import lombok.RequiredArgsConstructor;
 import com.studypals.domain.groupManage.dto.GroupEntryInfo;
 import com.studypals.domain.groupManage.service.GroupEntryService;
 
+/**
+ * 그룹 가입 관리에 대한 컨트롤러입니다. 담당하는 엔드포인트는 다음과 같습니다.
+ *
+ * <pre>
+ *     - POST /groups/{groupId}/join : 공개 그룹에 가입
+ *     - POST /groups/{groupId}/request-entry : 비공개 그룹 가입 요청
+ * </pre>
+ *
+ * @author s0o0bn
+ * @since 2025-04-25
+ */
 @RestController
 @RequestMapping("/groups")
 @RequiredArgsConstructor
@@ -23,6 +34,15 @@ public class GroupEntryController {
         Long joinId = groupEntryService.joinGroup(userId, new GroupEntryInfo(groupId, entryCode));
 
         return ResponseEntity.created(URI.create("/groups/" + groupId + "/members/" + joinId))
+                .build();
+    }
+
+    @PostMapping("/{groupId}/request-entry")
+    public ResponseEntity<Void> requestGroupParticipant(
+            @AuthenticationPrincipal Long userId, @PathVariable Long groupId, @RequestParam String entryCode) {
+        Long requestId = groupEntryService.requestParticipant(userId, new GroupEntryInfo(groupId, entryCode));
+
+        return ResponseEntity.created(URI.create("/groups/" + groupId + "/requests/" + requestId))
                 .build();
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -26,7 +26,7 @@ import com.studypals.domain.groupManage.service.GroupEntryService;
 @RequestMapping("/groups")
 @RequiredArgsConstructor
 public class GroupEntryController {
-    private GroupEntryService groupEntryService;
+    private final GroupEntryService groupEntryService;
 
     @PostMapping("/{groupId}/join")
     public ResponseEntity<Void> joinGroup(

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -32,7 +32,7 @@ public class GroupEntryController {
     public ResponseEntity<Void> joinGroup(@AuthenticationPrincipal Long userId, @RequestBody GroupEntryReq req) {
         Long joinId = groupEntryService.joinGroup(userId, req);
 
-        return ResponseEntity.created(URI.create("/groups/" + req.groupId() + "/members/" + joinId))
+        return ResponseEntity.created(URI.create(String.format("/groups/%d/members/%d", req.groupId(), joinId)))
                 .build();
     }
 
@@ -41,7 +41,7 @@ public class GroupEntryController {
             @AuthenticationPrincipal Long userId, @RequestBody GroupEntryReq req) {
         Long requestId = groupEntryService.requestParticipant(userId, req);
 
-        return ResponseEntity.created(URI.create("/groups/" + req.groupId() + "/requests/" + requestId))
+        return ResponseEntity.created(URI.create(String.format("/groups/%d/requests/%d", req.groupId(), requestId)))
                 .build();
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -8,15 +8,15 @@ import org.springframework.web.bind.annotation.*;
 
 import lombok.RequiredArgsConstructor;
 
-import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+import com.studypals.domain.groupManage.dto.GroupEntryReq;
 import com.studypals.domain.groupManage.service.GroupEntryService;
 
 /**
  * 그룹 가입 관리에 대한 컨트롤러입니다. 담당하는 엔드포인트는 다음과 같습니다.
  *
  * <pre>
- *     - POST /groups/{groupId}/join : 공개 그룹에 가입
- *     - POST /groups/{groupId}/request-entry : 비공개 그룹 가입 요청
+ *     - POST /groups/join : 공개 그룹에 가입
+ *     - POST /groups/request-entry : 비공개 그룹 가입 요청
  * </pre>
  *
  * @author s0o0bn
@@ -28,21 +28,20 @@ import com.studypals.domain.groupManage.service.GroupEntryService;
 public class GroupEntryController {
     private final GroupEntryService groupEntryService;
 
-    @PostMapping("/{groupId}/join")
-    public ResponseEntity<Void> joinGroup(
-            @AuthenticationPrincipal Long userId, @PathVariable Long groupId, @RequestParam String entryCode) {
-        Long joinId = groupEntryService.joinGroup(userId, new GroupEntryInfo(groupId, entryCode));
+    @PostMapping("/join")
+    public ResponseEntity<Void> joinGroup(@AuthenticationPrincipal Long userId, @RequestBody GroupEntryReq req) {
+        Long joinId = groupEntryService.joinGroup(userId, req);
 
-        return ResponseEntity.created(URI.create("/groups/" + groupId + "/members/" + joinId))
+        return ResponseEntity.created(URI.create("/groups/" + req.groupId() + "/members/" + joinId))
                 .build();
     }
 
-    @PostMapping("/{groupId}/request-entry")
+    @PostMapping("/request-entry")
     public ResponseEntity<Void> requestGroupParticipant(
-            @AuthenticationPrincipal Long userId, @PathVariable Long groupId, @RequestParam String entryCode) {
-        Long requestId = groupEntryService.requestParticipant(userId, new GroupEntryInfo(groupId, entryCode));
+            @AuthenticationPrincipal Long userId, @RequestBody GroupEntryReq req) {
+        Long requestId = groupEntryService.requestParticipant(userId, req);
 
-        return ResponseEntity.created(URI.create("/groups/" + groupId + "/requests/" + requestId))
+        return ResponseEntity.created(URI.create("/groups/" + req.groupId() + "/requests/" + requestId))
                 .build();
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupEntryRequestRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupEntryRequestRepository.java
@@ -1,0 +1,21 @@
+package com.studypals.domain.groupManage.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.studypals.domain.groupManage.entity.GroupEntryRequest;
+
+/**
+ * {@link GroupEntryRequest} 엔티티에 대한 dao 클래스입니다.
+ *
+ * <p>JPA 기반의 repository
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@code JpaRepository<GroupEntryRequest, Long>}
+ *
+ * @author s0o0bn
+ * @see GroupEntryRequest
+ * @since 2025-04-25
+ */
+@Repository
+public interface GroupEntryRequestRepository extends JpaRepository<GroupEntryRequest, Long> {}

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupRepository.java
@@ -1,6 +1,9 @@
 package com.studypals.domain.groupManage.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.groupManage.entity.Group;
@@ -18,4 +21,14 @@ import com.studypals.domain.groupManage.entity.Group;
  * @since 2025-04-12
  */
 @Repository
-public interface GroupRepository extends JpaRepository<Group, Long> {}
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    @Modifying
+    @Query(
+            """
+        UPDATE Group g
+        SET g.totalMember = g.totalMember + 1
+        WHERE g.id = :groupId AND g.totalMember < g.maxMember
+    """)
+    int increaseGroupMember(@Param("groupId") Long groupId);
+}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryInfo.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryInfo.java
@@ -1,0 +1,3 @@
+package com.studypals.domain.groupManage.dto;
+
+public record GroupEntryInfo(Long groupId, String entryCode) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryInfo.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryInfo.java
@@ -1,3 +1,0 @@
-package com.studypals.domain.groupManage.dto;
-
-public record GroupEntryInfo(Long groupId, String entryCode) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryReq.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryReq.java
@@ -1,0 +1,3 @@
+package com.studypals.domain.groupManage.dto;
+
+public record GroupEntryReq(Long groupId, String entryCode) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupSummaryRes.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupSummaryRes.java
@@ -18,7 +18,7 @@ public record GroupSummaryRes(
                 .id(group.getId())
                 .name(group.getName())
                 .tag(group.getTag())
-                .isOpen(group.getIsOpen())
+                .isOpen(group.isOpen())
                 .memberCount(group.getTotalMember())
                 .profiles(profiles.stream()
                         .map(it -> new GroupMemberProfileImageDto(it.imageUrl(), it.role()))

--- a/src/main/java/com/studypals/domain/groupManage/dto/mappers/GroupEntryRequestMapper.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/mappers/GroupEntryRequestMapper.java
@@ -1,0 +1,16 @@
+package com.studypals.domain.groupManage.dto.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.studypals.domain.groupManage.entity.Group;
+import com.studypals.domain.groupManage.entity.GroupEntryRequest;
+import com.studypals.domain.memberManage.entity.Member;
+
+@Mapper(componentModel = "spring")
+public interface GroupEntryRequestMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    GroupEntryRequest toEntity(Member member, Group group);
+}

--- a/src/main/java/com/studypals/domain/groupManage/dto/mappers/GroupEntryRequestMapper.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/mappers/GroupEntryRequestMapper.java
@@ -11,6 +11,6 @@ import com.studypals.domain.memberManage.entity.Member;
 public interface GroupEntryRequestMapper {
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "createdDate", ignore = true)
     GroupEntryRequest toEntity(Member member, Group group);
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/Group.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/Group.java
@@ -58,4 +58,8 @@ public class Group {
     @Column(name = "created_at")
     @CreatedDate
     private LocalDate createdDate;
+
+    public void joinNewMember() {
+        totalMember++;
+    }
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/Group.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/Group.java
@@ -49,11 +49,11 @@ public class Group {
 
     @Builder.Default
     @Column(name = "is_open", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
-    private Boolean isOpen = false;
+    private boolean isOpen = false;
 
     @Builder.Default
     @Column(name = "is_approval_required", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
-    private Boolean isApprovalRequired = false;
+    private boolean isApprovalRequired = false;
 
     @Column(name = "created_at")
     @CreatedDate

--- a/src/main/java/com/studypals/domain/groupManage/entity/Group.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/Group.java
@@ -62,10 +62,4 @@ public class Group {
     public boolean isFullMember() {
         return totalMember.equals(maxMember);
     }
-
-    public void joinNewMember() {
-        if (totalMember < maxMember) {
-            totalMember++;
-        }
-    }
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/Group.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/Group.java
@@ -59,7 +59,13 @@ public class Group {
     @CreatedDate
     private LocalDate createdDate;
 
+    public boolean isFullMember() {
+        return totalMember.equals(maxMember);
+    }
+
     public void joinNewMember() {
-        totalMember++;
+        if (totalMember < maxMember) {
+            totalMember++;
+        }
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/Group.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/Group.java
@@ -60,6 +60,6 @@ public class Group {
     private LocalDate createdDate;
 
     public boolean isFullMember() {
-        return totalMember.equals(maxMember);
+        return totalMember >= maxMember;
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryRequest.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryRequest.java
@@ -45,5 +45,5 @@ public class GroupEntryRequest {
 
     @Column(name = "created_at")
     @CreatedDate
-    private LocalDate createdAt;
+    private LocalDate createdDate;
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryRequest.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryRequest.java
@@ -1,0 +1,49 @@
+package com.studypals.domain.groupManage.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.*;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.*;
+
+import com.studypals.domain.memberManage.entity.Member;
+
+/**
+ * GroupEntryRequest 에 대한 엔티티입니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code builder} <br>
+ * 빌더 패턴을 사용하여 생성합니다. <br>
+ *
+ * @author s0o0bn
+ * @since 2025-04-25
+ */
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "group_entry_request")
+public class GroupEntryRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, unique = true)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDate createdAt;
+}

--- a/src/main/java/com/studypals/domain/groupManage/entity/GroupMember.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/GroupMember.java
@@ -27,7 +27,9 @@ import com.studypals.domain.memberManage.entity.Member;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
-@Table(name = "group_member")
+@Table(
+        name = "group_member",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"group_id", "member_id"})})
 public class GroupMember {
 
     @Id

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
@@ -2,7 +2,35 @@ package com.studypals.domain.groupManage.service;
 
 import com.studypals.domain.groupManage.dto.GroupEntryInfo;
 
+/**
+ * GroupEntryService 의 인터페이스입니다. 메서드를 정의합니다.
+ *
+ * <p>
+ *
+ * <p><b>상속 정보:</b><br>
+ * GroupEntryServiceImpl의 부모 인터페이스입니다.
+ *
+ * @author s0o0bn
+ * @see GroupEntryServiceImpl
+ * @since 2025-04-25
+ */
 public interface GroupEntryService {
 
+    /**
+     * 공개 그룹에 승인 없이 바로 가입합니다.
+     *
+     * @param userId 가입할 사용자 ID
+     * @param entryInfo 가입할 그룹 정보 {@link GroupEntryInfo}
+     * @return {@link com.studypals.domain.groupManage.entity.GroupMember} ID
+     */
     Long joinGroup(Long userId, GroupEntryInfo entryInfo);
+
+    /**
+     * 비공개 그룹에 가입 요청을 보냅니다.
+     *
+     * @param userId 요청할 사용자 ID
+     * @param entryInfo 요청할 그룹 정보 {@link GroupEntryInfo}
+     * @return {@link com.studypals.domain.groupManage.entity.GroupEntryRequest} ID
+     */
+    Long requestParticipant(Long userId, GroupEntryInfo entryInfo);
 }

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
@@ -1,0 +1,8 @@
+package com.studypals.domain.groupManage.service;
+
+import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+
+public interface GroupEntryService {
+
+    Long joinGroup(Long userId, GroupEntryInfo entryInfo);
+}

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
@@ -1,6 +1,6 @@
 package com.studypals.domain.groupManage.service;
 
-import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+import com.studypals.domain.groupManage.dto.GroupEntryReq;
 
 /**
  * GroupEntryService 의 인터페이스입니다. 메서드를 정의합니다.
@@ -20,17 +20,17 @@ public interface GroupEntryService {
      * 공개 그룹에 승인 없이 바로 가입합니다.
      *
      * @param userId 가입할 사용자 ID
-     * @param entryInfo 가입할 그룹 정보 {@link GroupEntryInfo}
+     * @param entryInfo 가입할 그룹 정보 {@link GroupEntryReq}
      * @return {@link com.studypals.domain.groupManage.entity.GroupMember} ID
      */
-    Long joinGroup(Long userId, GroupEntryInfo entryInfo);
+    Long joinGroup(Long userId, GroupEntryReq entryInfo);
 
     /**
      * 비공개 그룹에 가입 요청을 보냅니다.
      *
      * @param userId 요청할 사용자 ID
-     * @param entryInfo 요청할 그룹 정보 {@link GroupEntryInfo}
+     * @param entryInfo 요청할 그룹 정보 {@link GroupEntryReq}
      * @return {@link com.studypals.domain.groupManage.entity.GroupEntryRequest} ID
      */
-    Long requestParticipant(Long userId, GroupEntryInfo entryInfo);
+    Long requestParticipant(Long userId, GroupEntryReq entryInfo);
 }

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -5,7 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+import com.studypals.domain.groupManage.dto.GroupEntryReq;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.worker.GroupEntryCodeManager;
 import com.studypals.domain.groupManage.worker.GroupEntryRequestWorker;
@@ -39,7 +39,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
 
     @Override
     @Transactional
-    public Long joinGroup(Long userId, GroupEntryInfo entryInfo) {
+    public Long joinGroup(Long userId, GroupEntryReq entryInfo) {
         Group group = groupReader.getById(entryInfo.groupId());
         if (!group.isOpen()) {
             throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "can't join without permission");
@@ -52,7 +52,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
 
     @Override
     @Transactional
-    public Long requestParticipant(Long userId, GroupEntryInfo entryInfo) {
+    public Long requestParticipant(Long userId, GroupEntryReq entryInfo) {
         Group group = groupReader.getById(entryInfo.groupId());
         if (group.isOpen()) {
             throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "should join without permission");

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -32,10 +32,10 @@ import com.studypals.global.exceptions.exception.GroupException;
 @Service
 @RequiredArgsConstructor
 public class GroupEntryServiceImpl implements GroupEntryService {
-    private GroupReader groupReader;
-    private GroupMemberWorker groupMemberWorker;
-    private GroupEntryCodeManager entryCodeManager;
-    private GroupEntryRequestWorker entryRequestWorker;
+    private final GroupReader groupReader;
+    private final GroupMemberWorker groupMemberWorker;
+    private final GroupEntryCodeManager entryCodeManager;
+    private final GroupEntryRequestWorker entryRequestWorker;
 
     @Override
     @Transactional

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -11,6 +11,8 @@ import com.studypals.domain.groupManage.worker.GroupEntryCodeManager;
 import com.studypals.domain.groupManage.worker.GroupEntryRequestWorker;
 import com.studypals.domain.groupManage.worker.GroupMemberWorker;
 import com.studypals.domain.groupManage.worker.GroupReader;
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.memberManage.worker.MemberReader;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
 
@@ -32,6 +34,7 @@ import com.studypals.global.exceptions.exception.GroupException;
 @Service
 @RequiredArgsConstructor
 public class GroupEntryServiceImpl implements GroupEntryService {
+    private final MemberReader memberReader;
     private final GroupReader groupReader;
     private final GroupMemberWorker groupMemberWorker;
     private final GroupEntryCodeManager entryCodeManager;
@@ -59,6 +62,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
         }
 
         entryCodeManager.validateCode(group.getId(), entryInfo.entryCode());
-        return entryRequestWorker.createRequest(userId, group).getId();
+        Member member = memberReader.getRef(userId);
+        return entryRequestWorker.createRequest(member, group).getId();
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -41,7 +41,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
     @Transactional
     public Long joinGroup(Long userId, GroupEntryReq entryInfo) {
         Group group = groupReader.getById(entryInfo.groupId());
-        if (!group.isOpen()) {
+        if (group.isApprovalRequired()) {
             throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "can't join without permission");
         }
 
@@ -54,7 +54,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
     @Transactional
     public Long requestParticipant(Long userId, GroupEntryReq entryInfo) {
         Group group = groupReader.getById(entryInfo.groupId());
-        if (group.isOpen()) {
+        if (!group.isApprovalRequired()) {
             throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "should join without permission");
         }
 

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -44,15 +44,11 @@ public class GroupEntryServiceImpl implements GroupEntryService {
     @Transactional
     public Long joinGroup(Long userId, GroupEntryReq entryInfo) {
         Group group = groupReader.getById(entryInfo.groupId());
-        if (group.isFullMember()) {
-            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group already full of member");
-        }
         if (group.isApprovalRequired()) {
             throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "can't join without permission");
         }
 
         entryCodeManager.validateCodeBelongsToGroup(group.getId(), entryInfo.entryCode());
-        group.joinNewMember();
         return groupMemberWorker.createMember(userId, group).getId();
     }
 
@@ -60,13 +56,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
     @Transactional
     public Long requestParticipant(Long userId, GroupEntryReq entryInfo) {
         Group group = groupReader.getById(entryInfo.groupId());
-        if (group.isFullMember()) {
-            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group already full of member");
-        }
-        if (!group.isApprovalRequired()) {
-            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "should join without permission");
-        }
-
+        entryRequestWorker.validateNewRequestAvailable(group);
         entryCodeManager.validateCodeBelongsToGroup(group.getId(), entryInfo.entryCode());
         Member member = memberReader.getRef(userId);
         return entryRequestWorker.createRequest(member, group).getId();

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -1,0 +1,35 @@
+package com.studypals.domain.groupManage.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+import com.studypals.domain.groupManage.entity.Group;
+import com.studypals.domain.groupManage.worker.GroupEntryCodeManager;
+import com.studypals.domain.groupManage.worker.GroupMemberWorker;
+import com.studypals.domain.groupManage.worker.GroupReader;
+import com.studypals.global.exceptions.errorCode.GroupErrorCode;
+import com.studypals.global.exceptions.exception.GroupException;
+
+@Service
+@RequiredArgsConstructor
+public class GroupEntryServiceImpl implements GroupEntryService {
+    private GroupReader groupReader;
+    private GroupMemberWorker groupMemberWorker;
+    private GroupEntryCodeManager entryCodeManager;
+
+    @Override
+    @Transactional
+    public Long joinGroup(Long userId, GroupEntryInfo entryInfo) {
+        Group group = groupReader.getById(entryInfo.groupId());
+        if (!group.isOpen()) {
+            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "can't join without permission");
+        }
+
+        group.joinNewMember();
+        entryCodeManager.validateCode(group.getId(), entryInfo.entryCode());
+        return groupMemberWorker.createMember(userId, group).getId();
+    }
+}

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
@@ -44,10 +44,13 @@ public class GroupEntryCodeManager {
                 .getId();
     }
 
-    public void validateCode(Long groupId, String entryCode) {
+    public void validateCodeBelongsToGroup(Long groupId, String entryCode) {
         Long actualGroupId = getGroupId(entryCode);
         if (!actualGroupId.equals(groupId)) {
-            throw new GroupException(GroupErrorCode.GROUP_CODE_INVALID);
+            throw new GroupException(
+                    GroupErrorCode.GROUP_CODE_INVALID,
+                    String.format(
+                            "Invalid group code: expected groupId=%d, actual groupId=%d", groupId, actualGroupId));
         }
     }
 

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
@@ -44,6 +44,13 @@ public class GroupEntryCodeManager {
                 .getId();
     }
 
+    public void validateCode(Long groupId, String entryCode) {
+        Long actualGroupId = getGroupId(entryCode);
+        if (!actualGroupId.equals(groupId)) {
+            throw new GroupException(GroupErrorCode.GROUP_CODE_INVALID);
+        }
+    }
+
     private String generateNonDuplicatedCode() {
         String code;
         do {

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
@@ -1,0 +1,39 @@
+package com.studypals.domain.groupManage.worker;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.groupManage.dao.GroupEntryRequestRepository;
+import com.studypals.domain.groupManage.dto.mappers.GroupEntryRequestMapper;
+import com.studypals.domain.groupManage.entity.Group;
+import com.studypals.domain.groupManage.entity.GroupEntryRequest;
+import com.studypals.domain.memberManage.dao.MemberRepository;
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.global.annotations.Worker;
+
+/**
+ * group entry request 도메인의 기본 Worker 클래스입니다.
+ *
+ * <p>group entry request 관련 CUD 로직을 수행합니다.
+ *
+ *
+ * <p><b>빈 관리:</b><br>
+ * Worker
+ *
+ * @author s0o0bn
+ * @since 2025-04-25
+ */
+@Worker
+@RequiredArgsConstructor
+public class GroupEntryRequestWorker {
+    private MemberRepository memberRepository;
+    private GroupEntryRequestRepository entryRequestRepository;
+    private GroupEntryRequestMapper mapper;
+
+    public GroupEntryRequest createRequest(Long userId, Group group) {
+        Member member = memberRepository.getReferenceById(userId);
+        GroupEntryRequest entryRequest = mapper.toEntity(member, group);
+        entryRequestRepository.save(entryRequest);
+
+        return entryRequest;
+    }
+}

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
@@ -6,7 +6,6 @@ import com.studypals.domain.groupManage.dao.GroupEntryRequestRepository;
 import com.studypals.domain.groupManage.dto.mappers.GroupEntryRequestMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupEntryRequest;
-import com.studypals.domain.memberManage.dao.MemberRepository;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.global.annotations.Worker;
 
@@ -25,12 +24,10 @@ import com.studypals.global.annotations.Worker;
 @Worker
 @RequiredArgsConstructor
 public class GroupEntryRequestWorker {
-    private final MemberRepository memberRepository;
     private final GroupEntryRequestRepository entryRequestRepository;
     private final GroupEntryRequestMapper mapper;
 
-    public GroupEntryRequest createRequest(Long userId, Group group) {
-        Member member = memberRepository.getReferenceById(userId);
+    public GroupEntryRequest createRequest(Member member, Group group) {
         GroupEntryRequest entryRequest = mapper.toEntity(member, group);
         entryRequestRepository.save(entryRequest);
 

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
@@ -8,6 +8,8 @@ import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupEntryRequest;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.global.annotations.Worker;
+import com.studypals.global.exceptions.errorCode.GroupErrorCode;
+import com.studypals.global.exceptions.exception.GroupException;
 
 /**
  * group entry request 도메인의 기본 Worker 클래스입니다.
@@ -26,6 +28,15 @@ import com.studypals.global.annotations.Worker;
 public class GroupEntryRequestWorker {
     private final GroupEntryRequestRepository entryRequestRepository;
     private final GroupEntryRequestMapper mapper;
+
+    public void validateNewRequestAvailable(Group group) {
+        if (group.isFullMember()) {
+            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group already full of member");
+        }
+        if (!group.isApprovalRequired()) {
+            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "should join without permission");
+        }
+    }
 
     public GroupEntryRequest createRequest(Member member, Group group) {
         GroupEntryRequest entryRequest = mapper.toEntity(member, group);

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorker.java
@@ -25,9 +25,9 @@ import com.studypals.global.annotations.Worker;
 @Worker
 @RequiredArgsConstructor
 public class GroupEntryRequestWorker {
-    private MemberRepository memberRepository;
-    private GroupEntryRequestRepository entryRequestRepository;
-    private GroupEntryRequestMapper mapper;
+    private final MemberRepository memberRepository;
+    private final GroupEntryRequestRepository entryRequestRepository;
+    private final GroupEntryRequestMapper mapper;
 
     public GroupEntryRequest createRequest(Long userId, Group group) {
         Member member = memberRepository.getReferenceById(userId);

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberWorker.java
@@ -42,7 +42,7 @@ public class GroupMemberWorker {
     public GroupMember createMember(Long memberId, Group group) {
         int updated = groupRepository.increaseGroupMember(group.getId());
         if (updated == 0) {
-            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group member limit exceed");
+            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group member limit exceeded");
         }
 
         Member member = memberRepository.getReferenceById(memberId);

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberWorker.java
@@ -3,6 +3,7 @@ package com.studypals.domain.groupManage.worker;
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.groupManage.dao.GroupMemberRepository;
+import com.studypals.domain.groupManage.dao.GroupRepository;
 import com.studypals.domain.groupManage.dto.mappers.GroupMemberMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupMember;
@@ -29,6 +30,7 @@ import com.studypals.global.exceptions.exception.GroupException;
 @RequiredArgsConstructor
 public class GroupMemberWorker {
     private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMemberMapper groupMemberMapper;
 
@@ -38,6 +40,11 @@ public class GroupMemberWorker {
     }
 
     public GroupMember createMember(Long memberId, Group group) {
+        int updated = groupRepository.increaseGroupMember(group.getId());
+        if (updated == 0) {
+            throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group member limit exceed");
+        }
+
         Member member = memberRepository.getReferenceById(memberId);
         return create(member, group, GroupRole.MEMBER);
     }

--- a/src/main/java/com/studypals/global/exceptions/errorCode/GroupErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/GroupErrorCode.java
@@ -26,7 +26,6 @@ import com.studypals.global.responses.ResponseCode;
 public enum GroupErrorCode implements ErrorCode {
     // U02: User <-> Group 관련
     GROUP_NOT_FOUND(ResponseCode.GROUP_SEARCH, HttpStatus.NOT_FOUND, "can't find group"),
-    GROUP_CODE_NOT_FOUND(ResponseCode.GROUP_ENTRY_CODE, HttpStatus.NOT_FOUND, "invalid group entry code"),
     GROUP_FORBIDDEN(ResponseCode.GROUP_LEADER, HttpStatus.FORBIDDEN, "no authorization for managing group"),
     GROUP_CREATE_FAIL(ResponseCode.GROUP_CREATE, HttpStatus.BAD_REQUEST, "failed to createWithCategory group"),
     GROUP_DELETE_FAIL(ResponseCode.GROUP_DELETE, HttpStatus.BAD_REQUEST, "failed to delete group"),
@@ -35,6 +34,9 @@ public enum GroupErrorCode implements ErrorCode {
     GROUP_LEAVE_FAIL(ResponseCode.GROUP_LEAVE, HttpStatus.BAD_REQUEST, "failed to leave group"),
     GROUP_KICK_FAIL(ResponseCode.GROUP_KICK, HttpStatus.BAD_REQUEST, "failed to kick user from group"),
     GROUP_INVITE_FAIL(ResponseCode.GROUP_INVITE, HttpStatus.BAD_REQUEST, "failed to invite user to group"),
+
+    GROUP_CODE_NOT_FOUND(ResponseCode.GROUP_ENTRY_CODE, HttpStatus.NOT_FOUND, "can't find group entry code"),
+    GROUP_CODE_INVALID(ResponseCode.GROUP_ENTRY_CODE, HttpStatus.BAD_REQUEST, "invalid group entry code"),
 
     GROUP_MEMBER_NOT_FOUND(ResponseCode.GROUP_MEMBER_LIST, HttpStatus.NOT_FOUND, "can't find member in group"),
     GROUP_MEMBER_CREATE_FAIL(

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
@@ -1,0 +1,104 @@
+package com.studypals.domain.groupManage.restDocsTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.http.HttpDocumentation.httpRequest;
+import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.studypals.domain.groupManage.api.GroupEntryController;
+import com.studypals.domain.groupManage.dto.*;
+import com.studypals.domain.groupManage.service.GroupEntryService;
+import com.studypals.testModules.testSupport.RestDocsSupport;
+
+/**
+ * {@link GroupEntryController} 에 대한 rest docs web mvc test 입니다. 문서를 생성합니다.
+ *
+ * @author s0o0bn
+ * @see GroupEntryController
+ * @see RestDocsSupport
+ * @since 2025-04-12
+ */
+@WebMvcTest(GroupEntryController.class)
+public class GroupEntryControllerRestDocsTest extends RestDocsSupport {
+
+    //    @MockitoBean
+    //    private GroupService groupService;
+
+    @MockitoBean
+    private GroupEntryService groupEntryService;
+
+    @Test
+    @WithMockUser
+    void joinGroup_success() throws Exception {
+        // given
+        Long groupId = 1L;
+        Long joinId = 1L;
+        String entryCode = "1A2B3C";
+        GroupEntryReq req = new GroupEntryReq(groupId, entryCode);
+
+        given(groupEntryService.joinGroup(any(), eq(req))).willReturn(joinId);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/groups/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/groups/" + groupId + "/members/" + joinId))
+                .andDo(restDocs.document(
+                        httpRequest(),
+                        httpResponse(),
+                        requestFields(
+                                fieldWithPath("groupId").description("그룹 ID").attributes(constraints("not null")),
+                                fieldWithPath("entryCode")
+                                        .description("그룹 초대 코드")
+                                        .attributes(constraints("not null"))),
+                        responseHeaders(headerWithName("Location").description("추가된 그룹 멤버 id"))));
+    }
+
+    @Test
+    @WithMockUser
+    void requestParticipant_success() throws Exception {
+        // given
+        Long groupId = 1L;
+        Long requestId = 1L;
+        String entryCode = "1A2B3C";
+        GroupEntryReq req = new GroupEntryReq(groupId, entryCode);
+
+        given(groupEntryService.requestParticipant(any(), eq(req))).willReturn(requestId);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/groups/request-entry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/groups/" + groupId + "/requests/" + requestId))
+                .andDo(restDocs.document(
+                        httpRequest(),
+                        httpResponse(),
+                        requestFields(
+                                fieldWithPath("groupId").description("그룹 ID").attributes(constraints("not null")),
+                                fieldWithPath("entryCode")
+                                        .description("그룹 초대 코드")
+                                        .attributes(constraints("not null"))),
+                        responseHeaders(headerWithName("Location").description("추가된 그룹 가입 요청 id"))));
+    }
+}

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
@@ -11,7 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.studypals.domain.groupManage.dto.GroupEntryInfo;
+import com.studypals.domain.groupManage.dto.GroupEntryReq;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupEntryRequest;
 import com.studypals.domain.groupManage.entity.GroupMember;
@@ -46,7 +46,7 @@ public class GroupEntryServiceTest {
         Long userId = 1L;
         Long joinId = 1L;
         Group group = Group.builder().id(1L).isOpen(true).build();
-        GroupEntryInfo entryInfo = new GroupEntryInfo(group.getId(), "entryCode");
+        GroupEntryReq entryInfo = new GroupEntryReq(group.getId(), "entryCode");
         GroupMember groupMember = GroupMember.builder().id(joinId).build();
 
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
@@ -64,7 +64,7 @@ public class GroupEntryServiceTest {
         // given
         Long userId = 1L;
         Group group = Group.builder().isOpen(false).build();
-        GroupEntryInfo entryInfo = new GroupEntryInfo(1L, "entryCode");
+        GroupEntryReq entryInfo = new GroupEntryReq(1L, "entryCode");
 
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
 
@@ -79,7 +79,7 @@ public class GroupEntryServiceTest {
         // given
         Long userId = 1L;
         Group group = Group.builder().id(2L).isOpen(true).build();
-        GroupEntryInfo entryInfo = new GroupEntryInfo(1L, "entryCode");
+        GroupEntryReq entryInfo = new GroupEntryReq(1L, "entryCode");
 
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
         willThrow(new GroupException(GroupErrorCode.GROUP_JOIN_FAIL))
@@ -97,7 +97,7 @@ public class GroupEntryServiceTest {
         // given
         Long userId = 1L;
         Group group = Group.builder().id(1L).isOpen(false).build();
-        GroupEntryInfo entryInfo = new GroupEntryInfo(group.getId(), "entryCode");
+        GroupEntryReq entryInfo = new GroupEntryReq(group.getId(), "entryCode");
         GroupEntryRequest entryRequest = GroupEntryRequest.builder().id(1L).build();
 
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
@@ -115,7 +115,7 @@ public class GroupEntryServiceTest {
         // given
         Long userId = 1L;
         Group group = Group.builder().id(1L).isOpen(true).build();
-        GroupEntryInfo entryInfo = new GroupEntryInfo(group.getId(), "entryCode");
+        GroupEntryReq entryInfo = new GroupEntryReq(group.getId(), "entryCode");
 
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
 
@@ -130,7 +130,7 @@ public class GroupEntryServiceTest {
         // given
         Long userId = 1L;
         Group group = Group.builder().id(1L).isOpen(false).build();
-        GroupEntryInfo entryInfo = new GroupEntryInfo(group.getId(), "entryCode");
+        GroupEntryReq entryInfo = new GroupEntryReq(group.getId(), "entryCode");
 
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
         willThrow(new GroupException(GroupErrorCode.GROUP_JOIN_FAIL))

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
@@ -198,7 +198,7 @@ public class GroupServiceTest {
                 .id(group.getId())
                 .name(group.getName())
                 .tag(group.getTag())
-                .isOpen(group.getIsOpen())
+                .isOpen(group.isOpen())
                 .memberCount(group.getTotalMember())
                 .profiles(profiles.stream()
                         .map(it -> new GroupSummaryRes.GroupMemberProfileImageDto(it.imageUrl(), it.role()))

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidatorTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidatorTest.java
@@ -17,6 +17,15 @@ import com.studypals.domain.groupManage.entity.GroupMember;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
 
+/**
+ * {@link GroupAuthorityValidator} 에 대한 단위 테스트입니다.
+ *
+ * <p>성공 케이스와 예외 케이스에 대한 테스트입니다.
+ *
+ * @author s0o0bn
+ * @see GroupAuthorityValidator
+ * @since 2025-04-16
+ */
 @ExtendWith(MockitoExtension.class)
 public class GroupAuthorityValidatorTest {
 

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManagerTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManagerTest.java
@@ -80,7 +80,7 @@ public class GroupEntryCodeManagerTest {
     }
 
     @Test
-    void validateCode_success() {
+    void validateCodeBelongsToGroup_success() {
         // given
         Long groupId = 1L;
         String entryCode = "entry code";
@@ -89,11 +89,12 @@ public class GroupEntryCodeManagerTest {
         given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
 
         // when & then
-        assertThatCode(() -> entryCodeManager.validateCode(groupId, entryCode)).doesNotThrowAnyException();
+        assertThatCode(() -> entryCodeManager.validateCodeBelongsToGroup(groupId, entryCode))
+                .doesNotThrowAnyException();
     }
 
     @Test
-    void validateCode_fail_entryCodeNotEquals() {
+    void validateCodeBelongsToGroup_fail_entryCodeNotEquals() {
         // given
         Long groupId = 1L;
         String entryCode = "entry code";
@@ -102,7 +103,7 @@ public class GroupEntryCodeManagerTest {
         given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
 
         // when & then
-        assertThatThrownBy(() -> entryCodeManager.validateCode(groupId, entryCode))
+        assertThatThrownBy(() -> entryCodeManager.validateCodeBelongsToGroup(groupId, entryCode))
                 .extracting("errorCode")
                 .isEqualTo(GroupErrorCode.GROUP_CODE_INVALID);
     }

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManagerTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManagerTest.java
@@ -1,7 +1,6 @@
 package com.studypals.domain.groupManage.worker;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import java.util.Optional;
@@ -17,6 +16,15 @@ import com.studypals.domain.groupManage.entity.GroupEntryCode;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
 
+/**
+ * {@link GroupEntryCodeManager} 에 대한 단위 테스트입니다.
+ *
+ * <p>성공 케이스와 예외 케이스에 대한 테스트입니다.
+ *
+ * @author s0o0bn
+ * @see GroupEntryCodeManager
+ * @since 2025-04-16
+ */
 @ExtendWith(MockitoExtension.class)
 public class GroupEntryCodeManagerTest {
 
@@ -69,5 +77,33 @@ public class GroupEntryCodeManagerTest {
                 .isInstanceOf(GroupException.class)
                 .extracting("errorCode")
                 .isEqualTo(errorCode);
+    }
+
+    @Test
+    void validateCode_success() {
+        // given
+        Long groupId = 1L;
+        String entryCode = "entry code";
+        GroupEntryCode groupEntryCode = new GroupEntryCode(entryCode, groupId);
+
+        given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
+
+        // when & then
+        assertThatCode(() -> entryCodeManager.validateCode(groupId, entryCode)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validateCode_fail_entryCodeNotEquals() {
+        // given
+        Long groupId = 1L;
+        String entryCode = "entry code";
+        GroupEntryCode groupEntryCode = new GroupEntryCode(entryCode, 2L);
+
+        given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
+
+        // when & then
+        assertThatThrownBy(() -> entryCodeManager.validateCode(groupId, entryCode))
+                .extracting("errorCode")
+                .isEqualTo(GroupErrorCode.GROUP_CODE_INVALID);
     }
 }

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorkerTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorkerTest.java
@@ -1,0 +1,85 @@
+package com.studypals.domain.groupManage.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.studypals.domain.groupManage.dao.GroupEntryRequestRepository;
+import com.studypals.domain.groupManage.dto.mappers.GroupEntryRequestMapper;
+import com.studypals.domain.groupManage.entity.Group;
+import com.studypals.domain.groupManage.entity.GroupEntryRequest;
+import com.studypals.domain.memberManage.dao.MemberRepository;
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.global.exceptions.errorCode.GroupErrorCode;
+import com.studypals.global.exceptions.exception.GroupException;
+
+/**
+ * {@link GroupEntryRequestWorker} 에 대한 단위 테스트입니다.
+ *
+ * <p>성공 케이스와 예외 케이스에 대한 테스트입니다.
+ *
+ * @author s0o0bn
+ * @see GroupEntryRequestWorker
+ * @since 2025-04-25
+ */
+@ExtendWith(MockitoExtension.class)
+public class GroupEntryRequestWorkerTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GroupEntryRequestRepository entryRequestRepository;
+
+    @Mock
+    private GroupEntryRequestMapper entryRequestMapper;
+
+    @Mock
+    private Member mockMember;
+
+    @Mock
+    private Group mockGroup;
+
+    @Mock
+    private GroupEntryRequest mockGroupEntryRequest;
+
+    @InjectMocks
+    private GroupEntryRequestWorker entryRequestWorker;
+
+    @Test
+    void createRequest_success() {
+        // given
+        Long userId = 1L;
+
+        given(memberRepository.getReferenceById(userId)).willReturn(mockMember);
+        given(entryRequestMapper.toEntity(mockMember, mockGroup)).willReturn(mockGroupEntryRequest);
+
+        // when
+        GroupEntryRequest actual = entryRequestWorker.createRequest(userId, mockGroup);
+
+        // then
+        assertThat(actual).isEqualTo(mockGroupEntryRequest);
+    }
+
+    @Test
+    void createRequest_fail_whileSave() {
+        // given
+        Long userId = 1L;
+
+        given(memberRepository.getReferenceById(userId)).willReturn(mockMember);
+        given(entryRequestMapper.toEntity(mockMember, mockGroup)).willReturn(mockGroupEntryRequest);
+        given(entryRequestRepository.save(mockGroupEntryRequest))
+                .willThrow(new GroupException(GroupErrorCode.GROUP_JOIN_FAIL));
+
+        // when & then
+        assertThatThrownBy(() -> entryRequestWorker.createRequest(userId, mockGroup))
+                .extracting("errorCode")
+                .isEqualTo(GroupErrorCode.GROUP_JOIN_FAIL);
+    }
+}

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorkerTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryRequestWorkerTest.java
@@ -14,7 +14,6 @@ import com.studypals.domain.groupManage.dao.GroupEntryRequestRepository;
 import com.studypals.domain.groupManage.dto.mappers.GroupEntryRequestMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupEntryRequest;
-import com.studypals.domain.memberManage.dao.MemberRepository;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
@@ -30,9 +29,6 @@ import com.studypals.global.exceptions.exception.GroupException;
  */
 @ExtendWith(MockitoExtension.class)
 public class GroupEntryRequestWorkerTest {
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @Mock
     private GroupEntryRequestRepository entryRequestRepository;
@@ -57,11 +53,10 @@ public class GroupEntryRequestWorkerTest {
         // given
         Long userId = 1L;
 
-        given(memberRepository.getReferenceById(userId)).willReturn(mockMember);
         given(entryRequestMapper.toEntity(mockMember, mockGroup)).willReturn(mockGroupEntryRequest);
 
         // when
-        GroupEntryRequest actual = entryRequestWorker.createRequest(userId, mockGroup);
+        GroupEntryRequest actual = entryRequestWorker.createRequest(mockMember, mockGroup);
 
         // then
         assertThat(actual).isEqualTo(mockGroupEntryRequest);
@@ -72,13 +67,12 @@ public class GroupEntryRequestWorkerTest {
         // given
         Long userId = 1L;
 
-        given(memberRepository.getReferenceById(userId)).willReturn(mockMember);
         given(entryRequestMapper.toEntity(mockMember, mockGroup)).willReturn(mockGroupEntryRequest);
         given(entryRequestRepository.save(mockGroupEntryRequest))
                 .willThrow(new GroupException(GroupErrorCode.GROUP_JOIN_FAIL));
 
         // when & then
-        assertThatThrownBy(() -> entryRequestWorker.createRequest(userId, mockGroup))
+        assertThatThrownBy(() -> entryRequestWorker.createRequest(mockMember, mockGroup))
                 .extracting("errorCode")
                 .isEqualTo(GroupErrorCode.GROUP_JOIN_FAIL);
     }

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupMemberReaderTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupMemberReaderTest.java
@@ -15,6 +15,15 @@ import com.studypals.domain.groupManage.dao.GroupMemberRepository;
 import com.studypals.domain.groupManage.dto.GroupMemberProfileDto;
 import com.studypals.domain.groupManage.entity.GroupRole;
 
+/**
+ * {@link GroupMemberReader} 에 대한 단위 테스트입니다.
+ *
+ * <p>성공 케이스와 예외 케이스에 대한 테스트입니다.
+ *
+ * @author s0o0bn
+ * @see GroupMemberReader
+ * @since 2025-04-19
+ */
 @ExtendWith(MockitoExtension.class)
 public class GroupMemberReaderTest {
 

--- a/src/test/java/com/studypals/integrationTest/AbstractGroupIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/AbstractGroupIntegrationTest.java
@@ -1,0 +1,65 @@
+package com.studypals.integrationTest;
+
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+
+import lombok.Builder;
+
+import com.studypals.domain.groupManage.dao.GroupEntryCodeRedisRepository;
+import com.studypals.testModules.testSupport.IntegrationSupport;
+
+/**
+ * 그룹 관련 도메인에 대한 통합 테스트의 추상 클래스. {@link
+ * IntegrationSupport} 를 사용하였다.
+ *
+ * @author s0o0bn
+ * @see IntegrationSupport
+ * @since 2025-04-25
+ */
+public abstract class AbstractGroupIntegrationTest extends IntegrationSupport {
+    @Autowired
+    protected GroupEntryCodeRedisRepository entryCodeRedisRepository;
+
+    protected CreateGroupVar createGroup(Long userId, String name, String tag) {
+        return createGroup(userId, name, tag, true);
+    }
+
+    protected CreateGroupVar createGroup(Long userId, String name, String tag, boolean isApprovalRequired) {
+        String insertQuery =
+                """
+                INSERT INTO `group` (name, tag, is_approval_required)
+                VALUE(?, ?, ?)
+                """;
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(
+                con -> {
+                    PreparedStatement ps = con.prepareStatement(insertQuery, Statement.RETURN_GENERATED_KEYS);
+                    ps.setString(1, name);
+                    ps.setString(2, tag);
+                    ps.setBoolean(3, isApprovalRequired);
+                    return ps;
+                },
+                keyHolder);
+
+        Long groupId = Objects.requireNonNull(keyHolder.getKey()).longValue();
+
+        String memberInsertQuery =
+                """
+                INSERT INTO group_member (member_id, group_id, role, joined_at)
+                VALUE(?, ?, ?, ?)
+                """;
+        jdbcTemplate.update(memberInsertQuery, userId, groupId, "LEADER", LocalDate.now());
+
+        return CreateGroupVar.builder().groupId(groupId).name(name).tag(tag).build();
+    }
+
+    @Builder
+    protected record CreateGroupVar(Long groupId, String name, String tag) {}
+}

--- a/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.studypals.integrationTest;
+
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.studypals.domain.groupManage.dao.GroupEntryCodeRedisRepository;
+import com.studypals.domain.groupManage.dto.GroupEntryReq;
+import com.studypals.domain.groupManage.entity.GroupEntryCode;
+
+/**
+ * {@link com.studypals.domain.groupManage.api.GroupEntryController} 에 대한 통합 테스트 {@link
+ * AbstractGroupIntegrationTest} 를 사용하였다.
+ *
+ * @author s0o0bn
+ * @see com.studypals.domain.groupManage.api.GroupEntryController
+ * @see AbstractGroupIntegrationTest
+ * @since 2025-04-25
+ */
+@ActiveProfiles("test")
+@DisplayName("API TEST / 그룹 가입 관리 통합 테스트")
+public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
+    @Autowired
+    private GroupEntryCodeRedisRepository entryCodeRedisRepository;
+
+    @Test
+    @WithMockUser
+    void joinGroup_success() throws Exception {
+        // given
+        CreateUserVar user = createUser();
+        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag", false);
+        GroupEntryCode groupEntryCode = new GroupEntryCode("1A2B3C", group.groupId());
+        GroupEntryReq req = new GroupEntryReq(group.groupId(), groupEntryCode.getCode());
+
+        entryCodeRedisRepository.save(groupEntryCode);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/groups/join")
+                .header("Authorization", "Bearer " + user.getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(header().string("Location", matchesPattern("/groups/\\d+/members/\\d+")));
+    }
+
+    @Test
+    @WithMockUser
+    void requestParticipant_success() throws Exception {
+        // given
+        CreateUserVar user = createUser();
+        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
+        GroupEntryCode groupEntryCode = new GroupEntryCode("1A2B3C", group.groupId());
+        GroupEntryReq req = new GroupEntryReq(group.groupId(), groupEntryCode.getCode());
+
+        entryCodeRedisRepository.save(groupEntryCode);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/groups/request-entry")
+                .header("Authorization", "Bearer " + user.getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(header().string("Location", matchesPattern("/groups/\\d+/requests/\\d+")));
+    }
+}

--- a/src/test/java/com/studypals/integrationTest/GroupIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupIntegrationTest.java
@@ -6,40 +6,30 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.sql.PreparedStatement;
-import java.sql.Statement;
-import java.time.LocalDate;
-import java.util.Objects;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.ResultActions;
-
-import lombok.Builder;
 
 import com.studypals.domain.groupManage.dao.GroupEntryCodeRedisRepository;
 import com.studypals.domain.groupManage.dto.CreateGroupReq;
 import com.studypals.domain.groupManage.entity.GroupEntryCode;
 import com.studypals.global.responses.ResponseCode;
-import com.studypals.testModules.testSupport.IntegrationSupport;
 
 /**
  * {@link com.studypals.domain.groupManage.api.GroupController} 에 대한 통합 테스트 {@link
- * IntegrationSupport} 를 사용하였다.
+ * AbstractGroupIntegrationTest} 를 사용하였다.
  *
  * @author s0o0bn
  * @see com.studypals.domain.groupManage.api.GroupController
- * @see IntegrationSupport
+ * @see AbstractGroupIntegrationTest
  * @since 2025-04-12
  */
 @ActiveProfiles("test")
 @DisplayName("API TEST / 그룹 관리 통합 테스트")
-public class GroupIntegrationTest extends IntegrationSupport {
+public class GroupIntegrationTest extends AbstractGroupIntegrationTest {
     @Autowired
     private GroupEntryCodeRedisRepository entryCodeRedisRepository;
 
@@ -88,7 +78,7 @@ public class GroupIntegrationTest extends IntegrationSupport {
         CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
 
         // when
-        ResultActions result = mockMvc.perform(post("/groups/" + group.groupId + "/entry-code")
+        ResultActions result = mockMvc.perform(post("/groups/" + group.groupId() + "/entry-code")
                 .header("Authorization", "Bearer " + user.getAccessToken()));
 
         // then
@@ -128,36 +118,4 @@ public class GroupIntegrationTest extends IntegrationSupport {
         """;
         jdbcTemplate.update(sql, name);
     }
-
-    private CreateGroupVar createGroup(Long userId, String name, String tag) {
-        String insertQuery =
-                """
-                INSERT INTO `group` (name, tag)
-                VALUE(?, ?)
-                """;
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-
-        jdbcTemplate.update(
-                con -> {
-                    PreparedStatement ps = con.prepareStatement(insertQuery, Statement.RETURN_GENERATED_KEYS);
-                    ps.setString(1, name);
-                    ps.setString(2, tag);
-                    return ps;
-                },
-                keyHolder);
-
-        Long groupId = Objects.requireNonNull(keyHolder.getKey()).longValue();
-
-        String memberInsertQuery =
-                """
-                INSERT INTO group_member (member_id, group_id, role, joined_at)
-                VALUE(?, ?, ?, ?)
-                """;
-        jdbcTemplate.update(memberInsertQuery, userId, groupId, "LEADER", LocalDate.now());
-
-        return CreateGroupVar.builder().groupId(groupId).name(name).tag(tag).build();
-    }
-
-    @Builder
-    private record CreateGroupVar(Long groupId, String name, String tag) {}
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #61 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

그룹에 가입하는 API, 가입 요청하는 API 구현

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

### API 분리

가입 승인이 필요하지 않은 그룹에 바로 가입하는 것과, 승인이 필요한 그룹에 가입 요청을 보내는 것에 대해
처음엔 하나의 API에서 가입하려는 그룹의 승인 여부 `boolean` 값에 따라 로직을 분기하는 방식을 고려했습니다.

그러나 두 API의 목적이 비슷하지만 어쨌든 다른 책임이라고 생각해 그냥 API 자체를 분리하도록 했습니다.

### 리팩토링 여지

일단 가장 최근 discussion에서 말씀하신 내용에 따라 `MemberReader`를 서비스 단에서 사용하는 것은 적용해두었고,
현재 그룹 가입 관련 로직과 별개의 worker에 해당하는 부분은 별도의 리팩토링 이슈에서 처리하려고 남겨두었습니다.
(ex. `GroupAuthorityValidator`, `GroupMemberWorker`)

또한, 기존 `GroupController`에서 처리하던 그룹 초대 코드 생성, 초대코드로 요약 정보 조회는 해당 리팩토링 이슈에서 `GroupEntryController`로 이동될 예정입니다.

### 추가) 동시성 처리

현재 승인 없이 바로 가입 API에 대해 동시성 처리를 적용했습니다.

처음 고려한 방법이 낙관적 락, 비관적 락, 명시적 `UPDATE` (`@Modifying` 사용) 등 입니다.
각각에 대한 판단 근거는 다음과 같습니다.

**1. 낙관적 락**
우선, 낙관적 락 특성 상 두 트랜잭션에서 group의 `totalMember` 값이 5인 상태로 조회되었고 `maxMember`는 10이라면,
각각 스레드에서 해당 값을 증가시켰다면 먼저 DB에 반영된 트랜잭션은 성공할 것이고 나중에 업데이트한 트랜잭션은 버전이 달라서 실패할 것입니다.
그러나 이런 처리 방식은 요구사항에 적합하지 않으며, 실제로는 가입이 가능한데 다른 트랜잭션의 변경 사항에 의해 실패하게 됩니다.
따라서 해당 방식은 적합하지 않다고 판단했습니다.

**2. 비관적 락**
일단 비관적 락을 걸고 `Group`을 조회하게 되면, 트랜잭션 전체에 해당 락이 유지되어 처리 성능이 떨어질 것으로 판단했습니다.
`Group` 조회 역시 꼭 가입이 아닌 다른 요청에서도 많이 사용되는 로직이기에 영향을 미칠 것이라고 생각됩니다.

**3. 명시적 UPDATE**
`@Modifying` 어노테이션을 사용해 명시적으로 `totalMember` 값을 증가시키는 쿼리를 실행합니다.
해당 쿼리 조건에 `totalMember < maxMember`를 두어, 해당 조건에 일치하는 경우에만 동작합니다.
그렇지 않으면 totalMember가 업데이트 되지 않고, `GroupMemberWorker` 내부 로직에 의해 예외를 던집니다.
그러면 이후 `GroupMember`를 생성하는 것도 처리되지 않고 트랜잭션은 롤백되겠죠.
이 방식은 앞서 비관적 락과 달리 `UPDATE` 순간에만 해당 Group의 데이터 row에만 락을 걸게 되어 상대적으로 성능 이슈는 적을 것으로 생각됩니다.

명시적 UPDATE 방식의 주의점으로, "JPA의 영속성 컨텍스트 불일치와 더티 체킹이 불가함"이라는 문제가 있긴 한데
로직 상 해당 기능이 필요하지 않아 괜찮을 것 같습니다.

> 4. 분산락
동시성 처리 관련해 redis를 통한 분산락도 있긴 한데, 저희는 이전에 논의한 것처럼 단일 서버 환경을 고려하기에
오버엔지니어링이 될 것이라 판단해 고려하지 않았습니다.

> 5. 그외에 Java 자체에서 동시성 처리하는 방법도 있긴 한데(`synchronized`, `ReentrantLock`)
관련 개념에 대한 정보가 아직 부족해 일단은 고려하지 않았습니다.
더 찾아보고 현재 적용한 방식보다 적합하다고 판단되면 고려해보겠습니다.

아래 이미지와 같이 실제 동시성 처리 여부를 확인하는 SpringBootTest를 작성했습니다.
저희 운영 코드에는 반영하기는 좀 그래서 올리진 않고 로컬에서만 돌려보고 확인하는 용도로 그칠 것 같습니다.
<img width="619" alt="image" src="https://github.com/user-attachments/assets/1a148d86-795b-4add-a416-51c0cd99eb8f" />

아래와 같이 테스트 통과하는 것 확인했습니다.
<img width="397" alt="image" src="https://github.com/user-attachments/assets/20c8566d-8c37-4a5d-9533-165d444466f8" />


## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add new API endpoints for group joining and request joining features, including service implementations, validations, and integration tests.

### Why are these changes being made?
The changes are implemented to enable users to join public groups directly or request to join private groups requiring approval, facilitating better group management and access control. The approach ensures integration with existing systems using appropriate service and DAO patterns, with comprehensive testing for quality assurance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->