### PR TITLE
[#61][BUGFIX] 그룹 가입 통합 테스트 오류 수정

### DIFF
--- a/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
@@ -36,8 +36,8 @@ public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
     @WithMockUser
     void joinGroup_success() throws Exception {
         // given
-        CreateUserVar user = createUser();
-        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag", false);
+        CreateGroupVar group = createGroup(createUser().getUserId(), "group", "tag", false);
+        CreateUserVar user = createUser("member_username", "member");
         GroupEntryCode groupEntryCode = new GroupEntryCode("1A2B3C", group.groupId());
         GroupEntryReq req = new GroupEntryReq(group.groupId(), groupEntryCode.getCode());
 


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

통합 테스트에서 유저, 그룹 DB 저장 관련 오류 수정

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Reorder the creation of user and group instances in the `joinGroup_success` test within `GroupEntryIntegrationTest` to align with entity dependencies.

### Why are these changes being made?

To fix a bug where the creation order of user and group was incorrect, leading to potential issues in the test's execution. This approach ensures that the user is instantiated with the correct attributes before being associated with the group, thereby adhering to the logical flow of group creation and membership.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->