### PR TITLE
[#72][REFACTOR] 그룹 관련 리팩토링

### DIFF
--- a/src/asciidoc/api/group.adoc
+++ b/src/asciidoc/api/group.adoc
@@ -77,7 +77,9 @@ include::{snippets}/group-controller-rest-docs-test/create-group_success/http-re
 include::{snippets}/group-controller-rest-docs-test/create-group_success/response-headers.adoc[]
 include::{snippets}/group-controller-rest-docs-test/create-group_success/http-response.adoc[]
 
-==== 3. 초대 코드 생성
+=== 그룹 가입 관련 API
+
+==== 1. 초대 코드 생성
 
 *Description* +
 
@@ -89,17 +91,17 @@ include::{snippets}/group-controller-rest-docs-test/create-group_success/http-re
 
 '''
 
-include::{snippets}/group-controller-rest-docs-test/generate-entry-code_success/http-request.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_success/http-request.adoc[]
 
 *Response* +
 
 '''
 
-include::{snippets}/group-controller-rest-docs-test/generate-entry-code_success/response-headers.adoc[]
-include::{snippets}/group-controller-rest-docs-test/generate-entry-code_success/response-fields.adoc[]
-include::{snippets}/group-controller-rest-docs-test/generate-entry-code_success/http-response.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_success/response-headers.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_success/response-fields.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_success/http-response.adoc[]
 
-==== 4. 그룹 대표 정보 조회
+==== 2. 그룹 대표 정보 조회
 
 *Description* +
 
@@ -114,19 +116,17 @@ include::{snippets}/group-controller-rest-docs-test/generate-entry-code_success/
 
 '''
 
-include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/http-request.adoc[]
-include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/query-parameters.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_success/http-request.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_success/query-parameters.adoc[]
 
 *Response* +
 
 '''
 
-include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/http-response.adoc[]
-include::{snippets}/group-controller-rest-docs-test/get-group-summary_success/response-fields.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_success/http-response.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_success/response-fields.adoc[]
 
-=== 그룹 가입 관련 API
-
-==== 1. 그룹 가입
+==== 3. 그룹 가입
 
 *Description* +
 
@@ -149,7 +149,7 @@ include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/req
 include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/http-response.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/response-headers.adoc[]
 
-==== 2. 그룹 가입 요청
+==== 4. 그룹 가입 요청
 
 *Description* +
 

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupController.java
@@ -13,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.groupManage.dto.CreateGroupReq;
 import com.studypals.domain.groupManage.dto.GetGroupTagRes;
-import com.studypals.domain.groupManage.dto.GroupEntryCodeRes;
-import com.studypals.domain.groupManage.dto.GroupSummaryRes;
 import com.studypals.domain.groupManage.service.GroupService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
@@ -26,8 +24,6 @@ import com.studypals.global.responses.ResponseCode;
  * <pre>
  *     - GET /groups/tags : 그룹 태그 조회
  *     - POST /groups : 그룹 생성({@link CreateGroupReq})
- *     - POST /groups/{groupId}/entry-code : 그룹 초대 코드 생성
- *     - GET /groups/summary : 그룹 대표 정보 조회
  * </pre>
  *
  * @author s0o0bn
@@ -52,21 +48,5 @@ public class GroupController {
         Long groupId = groupService.createGroup(userId, request);
 
         return ResponseEntity.created(URI.create("/groups/" + groupId)).build();
-    }
-
-    @PostMapping("/{groupId}/entry-code")
-    public ResponseEntity<Response<GroupEntryCodeRes>> generateEntryCode(
-            @AuthenticationPrincipal Long userId, @PathVariable Long groupId) {
-        GroupEntryCodeRes codeResponse = groupService.generateEntryCode(userId, groupId);
-        Response<GroupEntryCodeRes> response = CommonResponse.success(ResponseCode.GROUP_ENTRY_CODE, codeResponse);
-
-        return ResponseEntity.created(URI.create("/groups/" + groupId + "/entry-code/" + codeResponse.code()))
-                .body(response);
-    }
-
-    @GetMapping("/summary")
-    public ResponseEntity<Response<GroupSummaryRes>> getGroupSummary(@RequestParam String entryCode) {
-        GroupSummaryRes response = groupService.getGroupSummary(entryCode);
-        return ResponseEntity.ok(CommonResponse.success(ResponseCode.GROUP_SUMMARY, response));
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -8,13 +8,20 @@ import org.springframework.web.bind.annotation.*;
 
 import lombok.RequiredArgsConstructor;
 
+import com.studypals.domain.groupManage.dto.GroupEntryCodeRes;
 import com.studypals.domain.groupManage.dto.GroupEntryReq;
+import com.studypals.domain.groupManage.dto.GroupSummaryRes;
 import com.studypals.domain.groupManage.service.GroupEntryService;
+import com.studypals.global.responses.CommonResponse;
+import com.studypals.global.responses.Response;
+import com.studypals.global.responses.ResponseCode;
 
 /**
  * 그룹 가입 관리에 대한 컨트롤러입니다. 담당하는 엔드포인트는 다음과 같습니다.
  *
  * <pre>
+ *     - POST /groups/{groupId}/entry-code : 그룹 초대 코드 생성
+ *     - GET /groups/summary : 그룹 대표 정보 조회
  *     - POST /groups/join : 공개 그룹에 가입
  *     - POST /groups/request-entry : 비공개 그룹 가입 요청
  * </pre>
@@ -27,6 +34,22 @@ import com.studypals.domain.groupManage.service.GroupEntryService;
 @RequiredArgsConstructor
 public class GroupEntryController {
     private final GroupEntryService groupEntryService;
+
+    @PostMapping("/{groupId}/entry-code")
+    public ResponseEntity<Response<GroupEntryCodeRes>> generateEntryCode(
+            @AuthenticationPrincipal Long userId, @PathVariable Long groupId) {
+        GroupEntryCodeRes codeResponse = groupEntryService.generateEntryCode(userId, groupId);
+        Response<GroupEntryCodeRes> response = CommonResponse.success(ResponseCode.GROUP_ENTRY_CODE, codeResponse);
+
+        return ResponseEntity.created(URI.create("/groups/" + groupId + "/entry-code/" + codeResponse.code()))
+                .body(response);
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<Response<GroupSummaryRes>> getGroupSummary(@RequestParam String entryCode) {
+        GroupSummaryRes response = groupEntryService.getGroupSummary(entryCode);
+        return ResponseEntity.ok(CommonResponse.success(ResponseCode.GROUP_SUMMARY, response));
+    }
 
     @PostMapping("/join")
     public ResponseEntity<Void> joinGroup(@AuthenticationPrincipal Long userId, @RequestBody GroupEntryReq req) {

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberRepository.java
@@ -23,6 +23,6 @@ import com.studypals.domain.groupManage.entity.GroupMember;
 @Repository
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>, GroupMemberCustomRepository {
 
-    @Query(value = "SELECT * FROM group_member WHERE member_id = :userId", nativeQuery = true)
-    Optional<GroupMember> findByMemberId(Long userId);
+    @Query(value = "SELECT * FROM group_member WHERE member_id = :userId AND group_id = :groupId", nativeQuery = true)
+    Optional<GroupMember> findByMemberIdAndGroupId(Long userId, Long groupId);
 }

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
@@ -1,6 +1,8 @@
 package com.studypals.domain.groupManage.service;
 
+import com.studypals.domain.groupManage.dto.GroupEntryCodeRes;
 import com.studypals.domain.groupManage.dto.GroupEntryReq;
+import com.studypals.domain.groupManage.dto.GroupSummaryRes;
 
 /**
  * GroupEntryService 의 인터페이스입니다. 메서드를 정의합니다.
@@ -15,6 +17,26 @@ import com.studypals.domain.groupManage.dto.GroupEntryReq;
  * @since 2025-04-25
  */
 public interface GroupEntryService {
+
+    /**
+     * 그룹 초대 코드를 생성한다.
+     * 코드 생성은 그룹장만 가능하다.
+     *
+     * @param userId 초대 코드를 생성한 사용자 ID
+     * @param groupId 코드를 생성할 그룹 ID
+     * @return 그룹 ID와 해당 그룹의 초대 코드
+     */
+    GroupEntryCodeRes generateEntryCode(Long userId, Long groupId);
+
+    /**
+     * 초대 코드로 그룹 대표 정보를 조회합니다.
+     * 그룹장 포함 일부 멤버들의 프로필 이미지와 함께 조회합니다.
+     *
+     * @param entryCode 그룹 초대 코드
+     * @return 그룹 대표 정보
+     * @throws com.studypals.global.exceptions.exception.GroupException
+     */
+    GroupSummaryRes getGroupSummary(String entryCode);
 
     /**
      * 공개 그룹에 승인 없이 바로 가입합니다.

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -49,7 +49,8 @@ public class GroupEntryServiceImpl implements GroupEntryService {
         }
 
         entryCodeManager.validateCodeBelongsToGroup(group.getId(), entryInfo.entryCode());
-        return groupMemberWorker.createMember(userId, group).getId();
+        Member member = memberReader.getRef(userId);
+        return groupMemberWorker.createMember(member, group).getId();
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupService.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 import com.studypals.domain.groupManage.dto.CreateGroupReq;
 import com.studypals.domain.groupManage.dto.GetGroupTagRes;
-import com.studypals.domain.groupManage.dto.GroupEntryCodeRes;
-import com.studypals.domain.groupManage.dto.GroupSummaryRes;
 
 /**
  * GroupService 의 인터페이스입니다. 메서드를 정의합니다.
@@ -37,24 +35,4 @@ public interface GroupService {
      * @throws com.studypals.global.exceptions.exception.GroupException
      */
     Long createGroup(Long userId, CreateGroupReq dto);
-
-    /**
-     * 그룹 초대 코드를 생성한다.
-     * 코드 생성은 그룹장만 가능하다.
-     *
-     * @param userId 초대 코드를 생성한 사용자 ID
-     * @param groupId 코드를 생성할 그룹 ID
-     * @return 그룹 ID와 해당 그룹의 초대 코드
-     */
-    GroupEntryCodeRes generateEntryCode(Long userId, Long groupId);
-
-    /**
-     * 초대 코드로 그룹 대표 정보를 조회합니다.
-     * 그룹장 포함 일부 멤버들의 프로필 이미지와 함께 조회합니다.
-     *
-     * @param entryCode 그룹 초대 코드
-     * @return 그룹 대표 정보
-     * @throws com.studypals.global.exceptions.exception.GroupException
-     */
-    GroupSummaryRes getGroupSummary(String entryCode);
 }

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -11,6 +11,8 @@ import com.studypals.domain.groupManage.dto.*;
 import com.studypals.domain.groupManage.dto.mappers.GroupMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.worker.*;
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.memberManage.worker.MemberReader;
 
 /**
  * group service 의 구현 클래스입니다.
@@ -32,6 +34,7 @@ import com.studypals.domain.groupManage.worker.*;
 public class GroupServiceImpl implements GroupService {
     private static final int GROUP_SUMMARY_MEMBER_COUNT = 5;
 
+    private final MemberReader memberReader;
     private final GroupWorker groupWorker;
     private final GroupReader groupReader;
     private final GroupMemberWorker groupMemberWorker;
@@ -51,7 +54,8 @@ public class GroupServiceImpl implements GroupService {
     @Transactional
     public Long createGroup(Long userId, CreateGroupReq dto) {
         Group group = groupWorker.create(dto);
-        groupMemberWorker.createLeader(userId, group);
+        Member member = memberReader.getRef(userId);
+        groupMemberWorker.createLeader(member, group);
         return group.getId();
     }
 

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -63,7 +63,7 @@ public class GroupServiceImpl implements GroupService {
     @Transactional(readOnly = true)
     public GroupEntryCodeRes generateEntryCode(Long userId, Long groupId) {
         Group group = groupReader.getById(groupId);
-        authorityValidator.validate(userId);
+        authorityValidator.validate(userId, groupId);
         String entryCode = entryCodeManager.generate(group.getId());
 
         return new GroupEntryCodeRes(group.getId(), entryCode);

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -32,17 +32,10 @@ import com.studypals.domain.memberManage.worker.MemberReader;
 @Service
 @RequiredArgsConstructor
 public class GroupServiceImpl implements GroupService {
-    private static final int GROUP_SUMMARY_MEMBER_COUNT = 5;
-
     private final MemberReader memberReader;
     private final GroupWorker groupWorker;
     private final GroupReader groupReader;
     private final GroupMemberWorker groupMemberWorker;
-    private final GroupMemberReader groupMemberReader;
-
-    private final GroupAuthorityValidator authorityValidator;
-    private final GroupEntryCodeManager entryCodeManager;
-
     private final GroupMapper groupMapper;
 
     @Override
@@ -57,26 +50,5 @@ public class GroupServiceImpl implements GroupService {
         Member member = memberReader.getRef(userId);
         groupMemberWorker.createLeader(member, group);
         return group.getId();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public GroupEntryCodeRes generateEntryCode(Long userId, Long groupId) {
-        Group group = groupReader.getById(groupId);
-        authorityValidator.validate(userId, groupId);
-        String entryCode = entryCodeManager.generate(group.getId());
-
-        return new GroupEntryCodeRes(group.getId(), entryCode);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public GroupSummaryRes getGroupSummary(String entryCode) {
-        Long groupId = entryCodeManager.getGroupId(entryCode);
-        Group group = groupReader.getById(groupId);
-        List<GroupMemberProfileDto> profiles =
-                groupMemberReader.getTopNMemberProfiles(groupId, GROUP_SUMMARY_MEMBER_COUNT);
-
-        return GroupSummaryRes.of(group, profiles);
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidator.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidator.java
@@ -26,9 +26,9 @@ import com.studypals.global.exceptions.exception.GroupException;
 public class GroupAuthorityValidator {
     private final GroupMemberRepository groupMemberRepository;
 
-    public void validate(Long memberId) {
+    public void validate(Long memberId, Long groupId) {
         GroupMember member = groupMemberRepository
-                .findByMemberId(memberId)
+                .findByMemberIdAndGroupId(memberId, groupId)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_MEMBER_NOT_FOUND));
         if (!member.isLeader()) {
             throw new GroupException(GroupErrorCode.GROUP_FORBIDDEN);

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberWorker.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberWorker.java
@@ -8,7 +8,6 @@ import com.studypals.domain.groupManage.dto.mappers.GroupMemberMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupMember;
 import com.studypals.domain.groupManage.entity.GroupRole;
-import com.studypals.domain.memberManage.dao.MemberRepository;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.global.annotations.Worker;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
@@ -29,23 +28,20 @@ import com.studypals.global.exceptions.exception.GroupException;
 @Worker
 @RequiredArgsConstructor
 public class GroupMemberWorker {
-    private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMemberMapper groupMemberMapper;
 
-    public GroupMember createLeader(Long memberId, Group group) {
-        Member member = memberRepository.getReferenceById(memberId);
+    public GroupMember createLeader(Member member, Group group) {
         return create(member, group, GroupRole.LEADER);
     }
 
-    public GroupMember createMember(Long memberId, Group group) {
+    public GroupMember createMember(Member member, Group group) {
         int updated = groupRepository.increaseGroupMember(group.getId());
         if (updated == 0) {
             throw new GroupException(GroupErrorCode.GROUP_JOIN_FAIL, "group member limit exceeded");
         }
 
-        Member member = memberRepository.getReferenceById(memberId);
         return create(member, group, GroupRole.MEMBER);
     }
 

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
@@ -10,8 +10,6 @@ import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -26,7 +24,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.groupManage.api.GroupController;
 import com.studypals.domain.groupManage.dto.*;
-import com.studypals.domain.groupManage.entity.GroupRole;
 import com.studypals.domain.groupManage.service.GroupService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
@@ -104,76 +101,5 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                                         .description("그룹 가입 시 승인 필요 여부 / Default FALSE")
                                         .attributes(constraints("not null"))),
                         responseHeaders(headerWithName("Location").description("추가된 그룹 id"))));
-    }
-
-    @Test
-    @WithMockUser
-    void generateEntryCode_success() throws Exception {
-        // given
-        Long groupId = 1L;
-        GroupEntryCodeRes entryCodeRes = new GroupEntryCodeRes(groupId, "A1B2C3");
-        Response<GroupEntryCodeRes> expected = CommonResponse.success(ResponseCode.GROUP_ENTRY_CODE, entryCodeRes);
-
-        given(groupService.generateEntryCode(any(), any())).willReturn(entryCodeRes);
-
-        // when
-        ResultActions result = mockMvc.perform(post("/groups/" + groupId + "/entry-code"));
-
-        // then
-        result.andExpect(status().isCreated())
-                .andExpect(header().string("Location", "/groups/1/entry-code/" + entryCodeRes.code()))
-                .andExpect(hasKey(expected))
-                .andDo(restDocs.document(
-                        httpRequest(),
-                        httpResponse(),
-                        responseFields(
-                                fieldWithPath("data.groupId").description("그룹 ID"),
-                                fieldWithPath("data.code").description("그룹 초대 코드 | 6자리의 대문자 알파벳, 숫자 조합"),
-                                fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("status").description("응답 상태"),
-                                fieldWithPath("message").description("응답 메시지")),
-                        responseHeaders(headerWithName("Location").description("생성된 그룹 초대 코드"))));
-    }
-
-    @Test
-    void getGroupSummary_success() throws Exception {
-        // given
-        String entryCode = "A1B2C3";
-        List<GroupSummaryRes.GroupMemberProfileImageDto> profiles = List.of(
-                new GroupSummaryRes.GroupMemberProfileImageDto("imageUrl url", GroupRole.LEADER),
-                new GroupSummaryRes.GroupMemberProfileImageDto("imageUrl url", GroupRole.MEMBER));
-        GroupSummaryRes groupSummaryRes = GroupSummaryRes.builder()
-                .id(1L)
-                .name("group name")
-                .tag("tag")
-                .isOpen(true)
-                .memberCount(2)
-                .profiles(profiles)
-                .build();
-        Response<GroupSummaryRes> expected = CommonResponse.success(ResponseCode.GROUP_SUMMARY, groupSummaryRes);
-
-        given(groupService.getGroupSummary(entryCode)).willReturn(groupSummaryRes);
-
-        // when
-        ResultActions result = mockMvc.perform(get("/groups/summary").param("entryCode", entryCode));
-
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(hasKey(expected))
-                .andDo(restDocs.document(
-                        httpRequest(),
-                        httpResponse(),
-                        queryParameters(parameterWithName("entryCode").description("그룹 초대 코드")),
-                        responseFields(
-                                fieldWithPath("data.id").description("그룹 ID"),
-                                fieldWithPath("data.name").description("그룹명"),
-                                fieldWithPath("data.tag").description("그룹 태그"),
-                                fieldWithPath("data.isOpen").description("그룹 공개 여부"),
-                                fieldWithPath("data.memberCount").description("그룹 전체 멤버 수"),
-                                fieldWithPath("data.profiles[].imageUrl").description("그룹 멤버 프로필 이미지"),
-                                fieldWithPath("data.profiles[].role").description("그룹 멤버 권한 | LEADER, MEMBER"),
-                                fieldWithPath("code").description("응답 코드"),
-                                fieldWithPath("status").description("응답 상태"),
-                                fieldWithPath("message").description("응답 메시지"))));
     }
 }

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
@@ -57,8 +57,9 @@ public class GroupEntryServiceTest {
         GroupEntryReq entryInfo = new GroupEntryReq(group.getId(), "entryCode");
         GroupMember groupMember = GroupMember.builder().id(joinId).build();
 
+        given(memberReader.getRef(userId)).willReturn(mockMember);
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
-        given(groupMemberWorker.createMember(userId, group)).willReturn(groupMember);
+        given(groupMemberWorker.createMember(mockMember, group)).willReturn(groupMember);
 
         // when
         Long actual = groupEntryService.joinGroup(userId, entryInfo);
@@ -121,10 +122,11 @@ public class GroupEntryServiceTest {
                 .build();
         GroupEntryReq entryInfo = new GroupEntryReq(1L, "entryCode");
 
+        given(memberReader.getRef(userId)).willReturn(mockMember);
         given(groupReader.getById(entryInfo.groupId())).willReturn(group);
         willThrow(new GroupException(GroupErrorCode.GROUP_JOIN_FAIL))
                 .given(groupMemberWorker)
-                .createMember(userId, group);
+                .createMember(mockMember, group);
 
         // when & then
         assertThatThrownBy(() -> groupEntryService.joinGroup(userId, entryInfo))

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
@@ -2,8 +2,12 @@ package com.studypals.domain.groupManage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,14 +15,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.studypals.domain.groupManage.dto.GroupEntryCodeRes;
 import com.studypals.domain.groupManage.dto.GroupEntryReq;
+import com.studypals.domain.groupManage.dto.GroupMemberProfileDto;
+import com.studypals.domain.groupManage.dto.GroupSummaryRes;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupEntryRequest;
 import com.studypals.domain.groupManage.entity.GroupMember;
-import com.studypals.domain.groupManage.worker.GroupEntryCodeManager;
-import com.studypals.domain.groupManage.worker.GroupEntryRequestWorker;
-import com.studypals.domain.groupManage.worker.GroupMemberWorker;
-import com.studypals.domain.groupManage.worker.GroupReader;
+import com.studypals.domain.groupManage.entity.GroupRole;
+import com.studypals.domain.groupManage.worker.*;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.memberManage.worker.MemberReader;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
@@ -43,10 +48,104 @@ public class GroupEntryServiceTest {
     private GroupEntryRequestWorker entryRequestWorker;
 
     @Mock
+    private GroupMemberReader groupMemberReader;
+
+    @Mock
+    private GroupAuthorityValidator authorityValidator;
+
+    @Mock
     private Member mockMember;
 
     @InjectMocks
     private GroupEntryServiceImpl groupEntryService;
+
+    @Test
+    void generateEntryCode_success() {
+        // given
+        Long userId = 1L;
+        Long groupId = 1L;
+        Group group = Group.builder().id(1L).build();
+        String entryCode = "A1B2C3";
+        GroupEntryCodeRes expected = new GroupEntryCodeRes(groupId, entryCode);
+
+        given(groupReader.getById(groupId)).willReturn(group);
+        given(entryCodeManager.generate(groupId)).willReturn(entryCode);
+
+        // when
+        GroupEntryCodeRes actual = groupEntryService.generateEntryCode(userId, groupId);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void generateEntryCode_fail_invalidAuthority() {
+        // given
+        Long userId = 1L;
+        Long groupId = 1L;
+        GroupErrorCode errorCode = GroupErrorCode.GROUP_FORBIDDEN;
+
+        willThrow(new GroupException(errorCode)).given(authorityValidator).validate(userId, groupId);
+
+        // when & then
+        assertThatThrownBy(() -> groupEntryService.generateEntryCode(userId, groupId))
+                .isInstanceOf(GroupException.class)
+                .extracting("errorCode")
+                .isEqualTo(errorCode);
+    }
+
+    @Test
+    void generateEntryCode_fail_groupNotFound() {
+        // given
+        Long userId = 1L;
+        Long groupId = 1L;
+        GroupErrorCode errorCode = GroupErrorCode.GROUP_NOT_FOUND;
+
+        given(groupReader.getById(groupId)).willThrow(new GroupException(errorCode));
+
+        // when & then
+        assertThatThrownBy(() -> groupEntryService.generateEntryCode(userId, groupId))
+                .isInstanceOf(GroupException.class)
+                .extracting("errorCode")
+                .isEqualTo(errorCode);
+    }
+
+    @Test
+    void getGroupSummary_success() {
+        // given
+        String entryCode = "entry code";
+        Group group = Group.builder()
+                .id(1L)
+                .name("group")
+                .tag("tag")
+                .isOpen(true)
+                .totalMember(5)
+                .build();
+        List<GroupMemberProfileDto> profiles = List.of(
+                new GroupMemberProfileDto(1L, "name", "imageUrl url", GroupRole.LEADER),
+                new GroupMemberProfileDto(2L, "name2", "imageUrl url", GroupRole.MEMBER));
+        GroupSummaryRes expected = GroupSummaryRes.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .tag(group.getTag())
+                .isOpen(group.isOpen())
+                .memberCount(group.getTotalMember())
+                .profiles(profiles.stream()
+                        .map(it -> new GroupSummaryRes.GroupMemberProfileImageDto(it.imageUrl(), it.role()))
+                        .toList())
+                .build();
+
+        given(entryCodeManager.getGroupId(entryCode)).willReturn(group.getId());
+        given(groupReader.getById(group.getId())).willReturn(group);
+        given(groupMemberReader.getTopNMemberProfiles(eq(group.getId()), anyInt()))
+                .willReturn(profiles);
+
+        // when
+        GroupSummaryRes actual = groupEntryService.getGroupSummary(entryCode);
+
+        // then
+        assertThat(actual).isEqualTo(expected);
+    }
 
     @Test
     void joinGroup_success() {

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
@@ -21,6 +21,8 @@ import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupRole;
 import com.studypals.domain.groupManage.entity.GroupTag;
 import com.studypals.domain.groupManage.worker.*;
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.memberManage.worker.MemberReader;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
 
@@ -35,6 +37,9 @@ import com.studypals.global.exceptions.exception.GroupException;
  */
 @ExtendWith(MockitoExtension.class)
 public class GroupServiceTest {
+
+    @Mock
+    private MemberReader memberReader;
 
     @Mock
     private GroupWorker groupWorker;
@@ -56,6 +61,9 @@ public class GroupServiceTest {
 
     @Mock
     private GroupMapper groupMapper;
+
+    @Mock
+    private Member mockMember;
 
     @Mock
     private Group mockGroup;
@@ -87,6 +95,7 @@ public class GroupServiceTest {
         Long userId = 1L;
         CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
 
+        given(memberReader.getRef(userId)).willReturn(mockMember);
         given(groupWorker.create(req)).willReturn(mockGroup);
 
         // when
@@ -119,8 +128,9 @@ public class GroupServiceTest {
         GroupErrorCode errorCode = GroupErrorCode.GROUP_MEMBER_CREATE_FAIL;
         CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
 
+        given(memberReader.getRef(userId)).willReturn(mockMember);
         given(groupWorker.create(req)).willReturn(mockGroup);
-        given(groupMemberWorker.createLeader(userId, mockGroup)).willThrow(new GroupException(errorCode));
+        given(groupMemberWorker.createLeader(mockMember, mockGroup)).willThrow(new GroupException(errorCode));
 
         // when & then
         assertThatThrownBy(() -> groupService.createGroup(userId, req))
@@ -155,7 +165,7 @@ public class GroupServiceTest {
         Long groupId = 1L;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_FORBIDDEN;
 
-        willThrow(new GroupException(errorCode)).given(authorityValidator).validate(userId);
+        willThrow(new GroupException(errorCode)).given(authorityValidator).validate(userId, groupId);
 
         // when & then
         assertThatThrownBy(() -> groupService.generateEntryCode(userId, groupId))

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidatorTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidatorTest.java
@@ -42,24 +42,26 @@ public class GroupAuthorityValidatorTest {
     void validate_success() {
         // given
         Long userId = 1L;
+        Long groupId = 1L;
 
         given(mockGroupMember.isLeader()).willReturn(true);
-        given(groupMemberRepository.findByMemberIdAndGroupId(userId)).willReturn(Optional.of(mockGroupMember));
+        given(groupMemberRepository.findByMemberIdAndGroupId(userId, groupId)).willReturn(Optional.of(mockGroupMember));
 
         // when & then
-        assertThatCode(() -> groupAuthorityValidator.validate(userId)).doesNotThrowAnyException();
+        assertThatCode(() -> groupAuthorityValidator.validate(userId, groupId)).doesNotThrowAnyException();
     }
 
     @Test
     void validate_fail_memberNotFound() {
         // given
         Long userId = 1L;
+        Long groupId = 1L;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_MEMBER_NOT_FOUND;
 
-        given(groupMemberRepository.findByMemberIdAndGroupId(userId)).willReturn(Optional.empty());
+        given(groupMemberRepository.findByMemberIdAndGroupId(userId, groupId)).willReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> groupAuthorityValidator.validate(userId))
+        assertThatThrownBy(() -> groupAuthorityValidator.validate(userId, groupId))
                 .isInstanceOf(GroupException.class)
                 .extracting("errorCode")
                 .isEqualTo(errorCode);
@@ -69,13 +71,14 @@ public class GroupAuthorityValidatorTest {
     void validate_fail_notAuthorized() {
         // given
         Long userId = 1L;
+        Long groupId = 1L;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_FORBIDDEN;
 
         given(mockGroupMember.isLeader()).willReturn(false);
-        given(groupMemberRepository.findByMemberIdAndGroupId(userId)).willReturn(Optional.of(mockGroupMember));
+        given(groupMemberRepository.findByMemberIdAndGroupId(userId, groupId)).willReturn(Optional.of(mockGroupMember));
 
         // when & then
-        assertThatThrownBy(() -> groupAuthorityValidator.validate(userId))
+        assertThatThrownBy(() -> groupAuthorityValidator.validate(userId, groupId))
                 .isInstanceOf(GroupException.class)
                 .extracting("errorCode")
                 .isEqualTo(errorCode);

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidatorTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupAuthorityValidatorTest.java
@@ -44,7 +44,7 @@ public class GroupAuthorityValidatorTest {
         Long userId = 1L;
 
         given(mockGroupMember.isLeader()).willReturn(true);
-        given(groupMemberRepository.findByMemberId(userId)).willReturn(Optional.of(mockGroupMember));
+        given(groupMemberRepository.findByMemberIdAndGroupId(userId)).willReturn(Optional.of(mockGroupMember));
 
         // when & then
         assertThatCode(() -> groupAuthorityValidator.validate(userId)).doesNotThrowAnyException();
@@ -56,7 +56,7 @@ public class GroupAuthorityValidatorTest {
         Long userId = 1L;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_MEMBER_NOT_FOUND;
 
-        given(groupMemberRepository.findByMemberId(userId)).willReturn(Optional.empty());
+        given(groupMemberRepository.findByMemberIdAndGroupId(userId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> groupAuthorityValidator.validate(userId))
@@ -72,7 +72,7 @@ public class GroupAuthorityValidatorTest {
         GroupErrorCode errorCode = GroupErrorCode.GROUP_FORBIDDEN;
 
         given(mockGroupMember.isLeader()).willReturn(false);
-        given(groupMemberRepository.findByMemberId(userId)).willReturn(Optional.of(mockGroupMember));
+        given(groupMemberRepository.findByMemberIdAndGroupId(userId)).willReturn(Optional.of(mockGroupMember));
 
         // when & then
         assertThatThrownBy(() -> groupAuthorityValidator.validate(userId))

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupMemberWorkerTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupMemberWorkerTest.java
@@ -16,7 +16,6 @@ import com.studypals.domain.groupManage.dto.mappers.GroupMemberMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupMember;
 import com.studypals.domain.groupManage.entity.GroupRole;
-import com.studypals.domain.memberManage.dao.MemberRepository;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
@@ -32,9 +31,6 @@ import com.studypals.global.exceptions.exception.GroupException;
  */
 @ExtendWith(MockitoExtension.class)
 public class GroupMemberWorkerTest {
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @Mock
     private GroupRepository groupRepository;
@@ -60,15 +56,13 @@ public class GroupMemberWorkerTest {
     @Test
     void createLeader_success() {
         // given
-        Long memberId = 1L;
         GroupRole role = GroupRole.LEADER;
 
         given(mockGroupMember.getRole()).willReturn(role);
-        given(memberRepository.getReferenceById(memberId)).willReturn(mockMember);
         given(groupMemberMapper.toEntity(mockMember, mockGroup, role)).willReturn(mockGroupMember);
 
         // when
-        GroupMember actual = groupMemberWorker.createLeader(memberId, mockGroup);
+        GroupMember actual = groupMemberWorker.createLeader(mockMember, mockGroup);
 
         // then
         assertThat(actual).isEqualTo(mockGroupMember);
@@ -78,16 +72,14 @@ public class GroupMemberWorkerTest {
     @Test
     void createLeader_fail_whileSave() {
         // given
-        Long memberId = 1L;
         GroupRole role = GroupRole.LEADER;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_MEMBER_CREATE_FAIL;
 
-        given(memberRepository.getReferenceById(memberId)).willReturn(mockMember);
         given(groupMemberMapper.toEntity(mockMember, mockGroup, role)).willReturn(mockGroupMember);
         given(groupMemberRepository.save(mockGroupMember)).willThrow(new GroupException(errorCode));
 
         // when & then
-        assertThatThrownBy(() -> groupMemberWorker.createLeader(memberId, mockGroup))
+        assertThatThrownBy(() -> groupMemberWorker.createLeader(mockMember, mockGroup))
                 .isInstanceOf(GroupException.class)
                 .extracting("errorCode")
                 .isEqualTo(errorCode);
@@ -96,18 +88,16 @@ public class GroupMemberWorkerTest {
     @Test
     void createMember_success() {
         // given
-        Long memberId = 1L;
         Long groupId = 1L;
         GroupRole role = GroupRole.MEMBER;
 
         given(mockGroup.getId()).willReturn(groupId);
         given(mockGroupMember.getRole()).willReturn(role);
         given(groupRepository.increaseGroupMember(groupId)).willReturn(1);
-        given(memberRepository.getReferenceById(memberId)).willReturn(mockMember);
         given(groupMemberMapper.toEntity(mockMember, mockGroup, role)).willReturn(mockGroupMember);
 
         // when
-        GroupMember actual = groupMemberWorker.createMember(memberId, mockGroup);
+        GroupMember actual = groupMemberWorker.createMember(mockMember, mockGroup);
 
         // then
         assertThat(actual).isEqualTo(mockGroupMember);
@@ -117,19 +107,17 @@ public class GroupMemberWorkerTest {
     @Test
     void createMember_fail_whileSave() {
         // given
-        Long memberId = 1L;
         Long groupId = 1L;
         GroupRole role = GroupRole.MEMBER;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_MEMBER_CREATE_FAIL;
 
         given(mockGroup.getId()).willReturn(groupId);
-        given(memberRepository.getReferenceById(memberId)).willReturn(mockMember);
         given(groupRepository.increaseGroupMember(groupId)).willReturn(1);
         given(groupMemberMapper.toEntity(mockMember, mockGroup, role)).willReturn(mockGroupMember);
         given(groupMemberRepository.save(mockGroupMember)).willThrow(new GroupException(errorCode));
 
         // when & then
-        assertThatThrownBy(() -> groupMemberWorker.createMember(memberId, mockGroup))
+        assertThatThrownBy(() -> groupMemberWorker.createMember(mockMember, mockGroup))
                 .isInstanceOf(GroupException.class)
                 .extracting("errorCode")
                 .isEqualTo(errorCode);
@@ -146,7 +134,7 @@ public class GroupMemberWorkerTest {
         given(groupRepository.increaseGroupMember(groupId)).willReturn(0);
 
         // when & then
-        assertThatThrownBy(() -> groupMemberWorker.createMember(memberId, mockGroup))
+        assertThatThrownBy(() -> groupMemberWorker.createMember(mockMember, mockGroup))
                 .isInstanceOf(GroupException.class)
                 .extracting("errorCode")
                 .isEqualTo(errorCode);

--- a/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
@@ -1,9 +1,11 @@
 package com.studypals.integrationTest;
 
+import static com.studypals.testModules.testUtils.JsonFieldResultMatcher.hasKey;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,10 +14,12 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.studypals.domain.groupManage.dao.GroupEntryCodeRedisRepository;
 import com.studypals.domain.groupManage.dto.GroupEntryReq;
 import com.studypals.domain.groupManage.entity.GroupEntryCode;
+import com.studypals.global.responses.ResponseCode;
 
 /**
  * {@link com.studypals.domain.groupManage.api.GroupEntryController} 에 대한 통합 테스트 {@link
@@ -31,6 +35,47 @@ import com.studypals.domain.groupManage.entity.GroupEntryCode;
 public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
     @Autowired
     private GroupEntryCodeRedisRepository entryCodeRedisRepository;
+
+    @Test
+    @DisplayName("POST /groups/:id/entry-code")
+    void generateEntryCode_success() throws Exception {
+        // given
+        CreateUserVar user = createUser();
+        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.post("/groups/" + group.groupId() + "/entry-code")
+                .header("Authorization", "Bearer " + user.getAccessToken()));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(header().string("Location", matchesPattern("/groups/\\d+/entry-code/[A-Z0-9]+")))
+                .andExpect(hasKey("code", ResponseCode.GROUP_ENTRY_CODE.getCode()))
+                .andExpect(jsonPath("$.data.code").isString());
+    }
+
+    @Test
+    @DisplayName("GET /groups/summary")
+    void getGroupSummary_success() throws Exception {
+        // given
+        CreateUserVar user = createUser();
+        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
+        GroupEntryCode entryCode = new GroupEntryCode("entry-code", group.groupId());
+
+        entryCodeRedisRepository.save(entryCode);
+
+        // when
+        ResultActions result = mockMvc.perform(get("/groups/summary")
+                .param("entryCode", entryCode.getCode())
+                .header("Authorization", "Bearer " + user.getAccessToken()));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(hasKey("code", ResponseCode.GROUP_SUMMARY.getCode()))
+                .andExpect(jsonPath("$.data.id").value(group.groupId()))
+                .andExpect(jsonPath("$.data.name").value(group.name()))
+                .andExpect(jsonPath("$.data.profiles.length()").value(1));
+    }
 
     @Test
     @WithMockUser

--- a/src/test/java/com/studypals/integrationTest/GroupIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupIntegrationTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.groupManage.dao.GroupEntryCodeRedisRepository;
 import com.studypals.domain.groupManage.dto.CreateGroupReq;
-import com.studypals.domain.groupManage.entity.GroupEntryCode;
 import com.studypals.global.responses.ResponseCode;
 
 /**
@@ -68,47 +67,6 @@ public class GroupIntegrationTest extends AbstractGroupIntegrationTest {
         // then
         result.andExpect(status().isCreated()).andExpect(header().string("Location", matchesPattern("/groups/\\d+")));
         ;
-    }
-
-    @Test
-    @DisplayName("POST /groups/:id/entry-code")
-    void generateEntryCode_success() throws Exception {
-        // given
-        CreateUserVar user = createUser();
-        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
-
-        // when
-        ResultActions result = mockMvc.perform(post("/groups/" + group.groupId() + "/entry-code")
-                .header("Authorization", "Bearer " + user.getAccessToken()));
-
-        // then
-        result.andExpect(status().isCreated())
-                .andExpect(header().string("Location", matchesPattern("/groups/\\d+/entry-code/[A-Z0-9]+")))
-                .andExpect(hasKey("code", ResponseCode.GROUP_ENTRY_CODE.getCode()))
-                .andExpect(jsonPath("$.data.code").isString());
-    }
-
-    @Test
-    @DisplayName("GET /groups/summary")
-    void getGroupSummary_success() throws Exception {
-        // given
-        CreateUserVar user = createUser();
-        CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
-        GroupEntryCode entryCode = new GroupEntryCode("entry-code", group.groupId());
-
-        entryCodeRedisRepository.save(entryCode);
-
-        // when
-        ResultActions result = mockMvc.perform(get("/groups/summary")
-                .param("entryCode", entryCode.getCode())
-                .header("Authorization", "Bearer " + user.getAccessToken()));
-
-        // then
-        result.andExpect(status().isOk())
-                .andExpect(hasKey("code", ResponseCode.GROUP_SUMMARY.getCode()))
-                .andExpect(jsonPath("$.data.id").value(group.groupId()))
-                .andExpect(jsonPath("$.data.name").value(group.name()))
-                .andExpect(jsonPath("$.data.profiles.length()").value(1));
     }
 
     private void createGroupTag(String name) {


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #72 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

Discussion #64 의 내용을 반영하고, 기존 `GroupController`에 있던 그룹 가입 관련 API를 `GroupEntryController`로 이동했습니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->

특별한 사항은 딱히 없고, 의견 제시하신 부분 리팩토링 적용했습니다.
API 이동 역시 기존 코드 변경 없이 담당하는 클래스 위치만 변경했습니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
