### PR TITLE
[#76][FEATURE] study time 테이블을 id-type 방식으로 변환

### DIFF
--- a/src/main/java/com/studypals/domain/studyManage/dao/StudyTimeRepository.java
+++ b/src/main/java/com/studypals/domain/studyManage/dao/StudyTimeRepository.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.studyManage.entity.StudyTime;
@@ -26,9 +28,33 @@ public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
     // tested
     List<StudyTime> findAllByMemberIdAndStudiedDateBetween(Long memberId, LocalDate start, LocalDate end);
 
-    Optional<StudyTime> findByMemberIdAndStudiedDateAndStudyTypeAndTypeId(
-            Long memberId, LocalDate studiedDate, StudyType type, Long typeId);
+    @Query(
+            value =
+                    """
+        SELECT * FROM study_time
+        WHERE member_id = :memberId
+        AND studied_Date = :studiedDate
+        AND study_type = :studyType
+        AND type_id = :typeId
+    """,
+            nativeQuery = true)
+    Optional<StudyTime> findByStudyType(
+            @Param("memberId") Long memberId,
+            @Param("studiedDate") LocalDate studiedDate,
+            @Param("studyType") StudyType studyType,
+            @Param("typeId") Long typeId);
 
-    Optional<StudyTime> findByMemberIdAndStudiedDateAndTemporaryName(
-            Long memberId, LocalDate studiedDate, String temporaryName);
+    @Query(
+            value =
+                    """
+        SELECT * FROM study_time
+        WHERE member_id = :memberId
+        AND studied_date = :studiedDate
+        AND temporary_name = :temporaryName
+    """,
+            nativeQuery = true)
+    Optional<StudyTime> findByTemporaryName(
+            @Param("memberId") Long memberId,
+            @Param("studiedDate") LocalDate studiedDate,
+            @Param("temporaryName") String temporaryName);
 }

--- a/src/main/java/com/studypals/domain/studyManage/dao/StudyTimeRepository.java
+++ b/src/main/java/com/studypals/domain/studyManage/dao/StudyTimeRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.studyManage.entity.StudyTime;
+import com.studypals.domain.studyManage.entity.StudyType;
 
 /**
  * {@link StudyTime} 에 대한 JPA DAO 클래스입니다.
@@ -25,9 +26,8 @@ public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
     // tested
     List<StudyTime> findAllByMemberIdAndStudiedDateBetween(Long memberId, LocalDate start, LocalDate end);
 
-    // tested
-    Optional<StudyTime> findByMemberIdAndStudiedDateAndCategoryId(
-            Long memberId, LocalDate studiedDate, Long categoryId);
+    Optional<StudyTime> findByMemberIdAndStudiedDateAndStudyTypeAndTypeId(
+            Long memberId, LocalDate studiedDate, StudyType type, Long typeId);
 
     Optional<StudyTime> findByMemberIdAndStudiedDateAndTemporaryName(
             Long memberId, LocalDate studiedDate, String temporaryName);

--- a/src/main/java/com/studypals/domain/studyManage/dao/StudyTimeRepository.java
+++ b/src/main/java/com/studypals/domain/studyManage/dao/StudyTimeRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.studyManage.entity.StudyTime;
-import com.studypals.domain.studyManage.entity.StudyType;
 
 /**
  * {@link StudyTime} 에 대한 JPA DAO 클래스입니다.
@@ -41,7 +40,7 @@ public interface StudyTimeRepository extends JpaRepository<StudyTime, Long> {
     Optional<StudyTime> findByStudyType(
             @Param("memberId") Long memberId,
             @Param("studiedDate") LocalDate studiedDate,
-            @Param("studyType") StudyType studyType,
+            @Param("studyType") String studyType,
             @Param("typeId") Long typeId);
 
     @Query(

--- a/src/main/java/com/studypals/domain/studyManage/dto/GetCategoryRes.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GetCategoryRes.java
@@ -12,4 +12,4 @@ import com.studypals.domain.studyManage.entity.StudyType;
  */
 @Builder
 public record GetCategoryRes(
-        StudyType type, Long typeId, String name, String color, Integer dayBelong, String description) {}
+        StudyType studyType, Long typeId, String name, String color, Integer dayBelong, String description) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GetCategoryRes.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GetCategoryRes.java
@@ -2,6 +2,8 @@ package com.studypals.domain.studyManage.dto;
 
 import lombok.Builder;
 
+import com.studypals.domain.studyManage.entity.StudyType;
+
 /**
  * 클라이언트가 study category 를 요청하면, 해당 record에 대한 list를 반환합니다.
  *
@@ -9,4 +11,5 @@ import lombok.Builder;
  * @since 2025-04-12
  */
 @Builder
-public record GetCategoryRes(Long categoryId, String name, String color, Integer dayBelong, String description) {}
+public record GetCategoryRes(
+        StudyType type, Long typeId, String name, String color, Integer dayBelong, String description) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GetStudyDto.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GetStudyDto.java
@@ -8,4 +8,4 @@ import com.studypals.domain.studyManage.entity.StudyType;
  * @author jack8
  * @since 2025-04-14
  */
-public record GetStudyDto(StudyType type, Long typeId, String temporaryName, Long time) {}
+public record GetStudyDto(StudyType studyType, Long typeId, String temporaryName, Long time) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GetStudyDto.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GetStudyDto.java
@@ -1,9 +1,11 @@
 package com.studypals.domain.studyManage.dto;
 
+import com.studypals.domain.studyManage.entity.StudyType;
+
 /**
  * 공부한 시간에 대한 정보를 가져올 때 사용합니다. 공부한 카테고리/이름에 대해서만 반환하도록 설계되었습니다.
  *
  * @author jack8
  * @since 2025-04-14
  */
-public record GetStudyDto(Long categoryId, String temporaryName, Long time) {}
+public record GetStudyDto(StudyType type, Long typeId, String temporaryName, Long time) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GetStudyRes.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GetStudyRes.java
@@ -11,4 +11,4 @@ import com.studypals.domain.studyManage.entity.StudyType;
  * @since 2025-04-14
  */
 @Builder
-public record GetStudyRes(StudyType type, Long typeId, String name, String color, String description, Long time) {}
+public record GetStudyRes(StudyType studyType, Long typeId, String name, String color, String description, Long time) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GetStudyRes.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GetStudyRes.java
@@ -2,6 +2,8 @@ package com.studypals.domain.studyManage.dto;
 
 import lombok.Builder;
 
+import com.studypals.domain.studyManage.entity.StudyType;
+
 /**
  * 카테고리 및 그에 따른 공부 시간을 반환받기 위한 response dto
  *
@@ -9,5 +11,4 @@ import lombok.Builder;
  * @since 2025-04-14
  */
 @Builder
-public record GetStudyRes(
-        Long categoryId, String name, String temporaryName, String color, String description, Long time) {}
+public record GetStudyRes(StudyType type, Long typeId, String name, String color, String description, Long time) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/StartStudyReq.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StartStudyReq.java
@@ -5,17 +5,18 @@ import java.time.LocalTime;
 import jakarta.validation.constraints.AssertTrue;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.studypals.domain.studyManage.entity.StudyType;
 
 /**
- * 공부 시작 시 시의 데이터입니다. categoryId 와 temporaryName은 하나만 존재할 수 있습니다.
+ * 공부 시작 시 시의 데이터입니다. typeId 와 temporaryName은 하나만 존재할 수 있습니다.
  *
  * @author jack8
  * @since 2025-04-13
  */
-public record StartStudyReq(Long categoryId, String temporaryName, LocalTime startTime) {
-    @AssertTrue(message = "categoryId와 temporaryName 중 하나만 존재해야 합니다.")
+public record StartStudyReq(StudyType type, Long typeId, String temporaryName, LocalTime startTime) {
+    @AssertTrue(message = "typeId 와 temporaryName 중 하나만 존재해야 합니다.")
     @JsonIgnore
     public boolean isValidExclusive() {
-        return (categoryId != null && temporaryName == null) || (categoryId == null && temporaryName != null);
+        return (typeId != null && temporaryName == null) || (typeId == null && temporaryName != null);
     }
 }

--- a/src/main/java/com/studypals/domain/studyManage/dto/StartStudyReq.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StartStudyReq.java
@@ -13,7 +13,7 @@ import com.studypals.domain.studyManage.entity.StudyType;
  * @author jack8
  * @since 2025-04-13
  */
-public record StartStudyReq(StudyType type, Long typeId, String temporaryName, LocalTime startTime) {
+public record StartStudyReq(StudyType studyType, Long typeId, String temporaryName, LocalTime startTime) {
     @AssertTrue(message = "typeId 와 temporaryName 중 하나만 존재해야 합니다.")
     @JsonIgnore
     public boolean isValidExclusive() {

--- a/src/main/java/com/studypals/domain/studyManage/dto/StartStudyRes.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StartStudyRes.java
@@ -16,4 +16,9 @@ import com.studypals.domain.studyManage.entity.StudyType;
  * @since 2025-04-13
  */
 public record StartStudyRes(
-        boolean studying, LocalTime startTime, Long studyTime, StudyType type, Long typeId, String temporaryName) {}
+        boolean studying,
+        LocalTime startTime,
+        Long studyTime,
+        StudyType studyType,
+        Long typeId,
+        String temporaryName) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/StartStudyRes.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StartStudyRes.java
@@ -3,6 +3,7 @@ package com.studypals.domain.studyManage.dto;
 import java.time.LocalTime;
 
 import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.domain.studyManage.entity.StudyType;
 
 /**
  * 공부 시작에 대한 dto 입니다. controller -> service
@@ -15,4 +16,4 @@ import com.studypals.domain.studyManage.entity.StudyStatus;
  * @since 2025-04-13
  */
 public record StartStudyRes(
-        boolean studying, LocalTime startTime, Long studyTime, Long categoryId, String temporaryName) {}
+        boolean studying, LocalTime startTime, Long studyTime, StudyType type, Long typeId, String temporaryName) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/StudyList.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StudyList.java
@@ -10,4 +10,10 @@ import com.studypals.domain.studyManage.entity.StudyType;
  * @see GetDailyStudyDto
  * @since 2025-04-19
  */
-public record StudyList(StudyType type, Long typeId, String temporaryName, Long time) {}
+public record StudyList(StudyType type, Long typeId, String temporaryName, Long time) {
+    public StudyList {
+        if (time != null && time < 0) {
+            throw new IllegalArgumentException("study time must be non-negative");
+        }
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/dto/StudyList.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StudyList.java
@@ -1,5 +1,7 @@
 package com.studypals.domain.studyManage.dto;
 
+import com.studypals.domain.studyManage.entity.StudyType;
+
 /**
  * 하루 동안 공부한 카테고리 혹은 임시 토픽 등의 데이터에 대한 리스트를 구성하기 위한 dto
  *
@@ -8,4 +10,4 @@ package com.studypals.domain.studyManage.dto;
  * @see GetDailyStudyDto
  * @since 2025-04-19
  */
-public record StudyList(Long categoryId, String temporaryName, Long time) {}
+public record StudyList(StudyType type, Long typeId, String temporaryName, Long time) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/StudyList.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/StudyList.java
@@ -10,7 +10,7 @@ import com.studypals.domain.studyManage.entity.StudyType;
  * @see GetDailyStudyDto
  * @since 2025-04-19
  */
-public record StudyList(StudyType type, Long typeId, String temporaryName, Long time) {
+public record StudyList(StudyType studyType, Long typeId, String temporaryName, Long time) {
     public StudyList {
         if (time != null && time < 0) {
             throw new IllegalArgumentException("study time must be non-negative");

--- a/src/main/java/com/studypals/domain/studyManage/dto/mappers/CategoryMapper.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/mappers/CategoryMapper.java
@@ -29,6 +29,6 @@ public interface CategoryMapper {
     @Mapping(target = "member", source = "member")
     StudyCategory toEntity(CreateCategoryReq req, Member member);
 
-    @Mapping(source = "id", target = "categoryId")
+    @Mapping(source = "id", target = "typeId")
     GetCategoryRes toDto(StudyCategory entity);
 }

--- a/src/main/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapper.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapper.java
@@ -1,7 +1,6 @@
 package com.studypals.domain.studyManage.dto.mappers;
 
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 import com.studypals.domain.studyManage.dto.GetStudyDto;
 import com.studypals.domain.studyManage.dto.StartStudyRes;
@@ -21,7 +20,6 @@ public interface StudyTimeMapper {
 
     StartStudyRes toDto(StudyStatus entity);
 
-    @Mapping(target = "type", source = "studyType")
     GetStudyDto toDto(StudyTime entity);
 
     StudyList toStudyDto(StudyTime entity);

--- a/src/main/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapper.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapper.java
@@ -5,6 +5,7 @@ import org.mapstruct.Mapping;
 
 import com.studypals.domain.studyManage.dto.GetStudyDto;
 import com.studypals.domain.studyManage.dto.StartStudyRes;
+import com.studypals.domain.studyManage.dto.StudyList;
 import com.studypals.domain.studyManage.entity.StudyStatus;
 import com.studypals.domain.studyManage.entity.StudyTime;
 
@@ -20,6 +21,8 @@ public interface StudyTimeMapper {
 
     StartStudyRes toDto(StudyStatus entity);
 
-    @Mapping(target = "categoryId", source = "category.id")
+    @Mapping(target = "type", source = "studyType")
     GetStudyDto toDto(StudyTime entity);
+
+    StudyList toStudyDto(StudyTime entity);
 }

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
@@ -23,6 +23,9 @@ import lombok.Getter;
  * LocalTime startTime;
  * Long studyTime;
  * Long expiration;
+ * StudyType studyType;
+ * Long typeId;
+ * String temporaryName;
  *     }
  * </pre>
  *
@@ -45,7 +48,9 @@ public class StudyStatus {
     @Builder.Default
     private Long studyTime = 0L;
 
-    private Long categoryId;
+    private StudyType studyType;
+
+    private Long typeId;
 
     private String temporaryName;
 

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyTime.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyTime.java
@@ -11,21 +11,9 @@ import lombok.*;
 import com.studypals.domain.memberManage.entity.Member;
 
 /**
- * 공부 시간에 대한 엔티티입니다. JPA 에 의해 관리됩니다.
- * <p>
- * 다음과 같은 필드를 가지고 있습니다.
- * <pre>
- *     {@code
- * Long id;
- * Member member;
- * StudyCategory studyCategory;
- * LocalDate studiedDate;
- * Long time;
- *     }
- * </pre>
- * temporaryName 은 사용자가 category 에 포함되지 않은 내용을
- * 임시로 사용할 때 부여되는 이름입니다. 만약 category 가 null 인 경우, 해당
- * 이름을 반환합니다. 둘 중 하나의 값이 존재해야 한다는 강제성을 부여하였습니다.
+ * 공부 시간을 나타내는 JPA entity 클래스입니다.
+ * study_time 테이블과 매핑됩니다.
+ *
  * <p><b>주요 생성자:</b><br>
  * {@code Builder}  <br>
  * builder 패턴을 통해 생성합니다. <br>
@@ -40,7 +28,7 @@ import com.studypals.domain.memberManage.entity.Member;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
         name = "study_time",
-        indexes = {@Index(name = "idx_member_studied_category", columnList = "member_id, studied_at, category_id")})
+        indexes = {@Index(name = "idx_member_studied", columnList = "member_id, studied_at")})
 public class StudyTime {
 
     @Id
@@ -52,9 +40,12 @@ public class StudyTime {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = true)
-    private StudyCategory category;
+    @Column(name = "study_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StudyType studyType;
+
+    @Column(name = "type_id")
+    private Long typeId;
 
     @Column(name = "temporary_name", nullable = true, length = 255)
     private String temporaryName;
@@ -69,8 +60,8 @@ public class StudyTime {
     @PrePersist
     @PreUpdate
     private void validateTemporaryOrCategory() {
-        if (this.temporaryName == null && this.category == null) {
-            throw new DataIntegrityViolationException("must have value temporary name or category");
+        if (this.temporaryName == null && this.typeId == null) {
+            throw new DataIntegrityViolationException("must have value temporary name or typeId");
         }
     }
 

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyTime.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyTime.java
@@ -50,7 +50,7 @@ public class StudyTime {
     @Column(name = "temporary_name", nullable = true, length = 255)
     private String temporaryName;
 
-    @Column(name = "studied_at", nullable = false)
+    @Column(name = "studied_date", nullable = false)
     private LocalDate studiedDate;
 
     @Column(name = "time", nullable = false)

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyTime.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyTime.java
@@ -28,7 +28,7 @@ import com.studypals.domain.memberManage.entity.Member;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(
         name = "study_time",
-        indexes = {@Index(name = "idx_member_studied", columnList = "member_id, studied_at")})
+        indexes = {@Index(name = "idx_member_studied", columnList = "member_id, studied_date")})
 public class StudyTime {
 
     @Id

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyType.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyType.java
@@ -1,0 +1,16 @@
+package com.studypals.domain.studyManage.entity;
+
+/**
+ *
+ * {@link StudyTime} 에서 FK 를 대신하여, 다른 엔티티에 대한 느슨한 연관관계를 위한 엔티티 타입을 명시합니다.
+ * <p>
+ * PERSONAL,GROUP, TEMPORARY 등을 정의합니다.
+ *
+ * @author jack8
+ * @since 2025-05-05
+ */
+public enum StudyType {
+    PERSONAL,
+    GROUP,
+    TEMPORARY
+}

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyType.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyType.java
@@ -4,8 +4,11 @@ package com.studypals.domain.studyManage.entity;
  *
  * {@link StudyTime} 에서 FK 를 대신하여, 다른 엔티티에 대한 느슨한 연관관계를 위한 엔티티 타입을 명시합니다.
  * <p>
- * PERSONAL,GROUP, TEMPORARY 등을 정의합니다.
- *
+ * <pre>
+ * PERSONAL: 개인이 직접 설정한 공부 카테고리(토픽) - study_category table과의 연관
+ * GROUP: 그룹이 설정한 공부 카테고리(토픽)
+ * TEMPORARY: 임시-단 한번의 공부를 위한 카테고리 이름
+ * </pre>
  * @author jack8
  * @since 2025-05-05
  */

--- a/src/main/java/com/studypals/domain/studyManage/facade/StudyTimeFacade.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/StudyTimeFacade.java
@@ -1,7 +1,6 @@
 package com.studypals.domain.studyManage.facade;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -9,6 +8,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.studyManage.dto.*;
+import com.studypals.domain.studyManage.entity.StudyType;
+import com.studypals.domain.studyManage.facade.strategy.StudyRenderStrategyFactory;
 import com.studypals.domain.studyManage.service.DailyStudyInfoService;
 import com.studypals.domain.studyManage.service.StudyCategoryService;
 import com.studypals.domain.studyManage.service.StudyTimeService;
@@ -32,6 +33,7 @@ public class StudyTimeFacade {
     private final StudyTimeService studyTimeService;
     private final StudyCategoryService studyCategoryService;
     private final DailyStudyInfoService dailyStudyInfoService;
+    private final StudyRenderStrategyFactory strategyFactory;
 
     /**
      * 특정 날짜의 공부 시간을 반환한다. studyTimeService 로부터 해당 날짜에 공부한 기록 및,
@@ -42,11 +44,13 @@ public class StudyTimeFacade {
      * @return 해당 날짜의 공부 기록(카테고리, 혹은 임시 이름 기반 공부 시간 등)
      */
     public List<GetStudyRes> getStudyTimeByDate(Long userId, LocalDate date) {
-
         List<GetStudyDto> studies = studyTimeService.getStudyList(userId, date);
-        List<GetCategoryRes> categories = studyCategoryService.getUserCategoryByDate(userId, date);
 
-        return toStudyResList(studies, categories);
+        // 고민 중... 해당 부분도 전략 패턴으로 옮기는게 맞을까?
+        // 유지보수성이냐(전략 패턴에 옮기기), 객체의 책임의 분리냐(현재 위치 유지)
+        List<GetCategoryRes> personalCategories = studyCategoryService.getUserCategory(userId);
+
+        return strategyFactory.compose(studies, Map.of(StudyType.PERSONAL, personalCategories));
     }
 
     /**
@@ -58,66 +62,11 @@ public class StudyTimeFacade {
      * @return 특정 날짜 구간에 대한 공부 정보 리스트
      */
     public List<GetDailyStudyRes> getDailyStudyTimeByPeriod(Long userId, PeriodDto period) {
-        List<GetDailyStudyDto> studies = studyTimeService.getDailyStudyList(userId, period);
+        List<GetDailyStudyDto> dailyStudies = studyTimeService.getDailyStudyList(userId, period);
         List<GetDailyStudyInfoDto> infos = dailyStudyInfoService.getDailyStudyInfoList(userId, period);
 
-        return toDailyStudyList(studies, infos);
-    }
-
-    /**
-     * 카테고리 리스트와 공부 시간 리스트를 취합하여 하나의 리스트로 만드는 메서드.
-     * 만약 카테고리에는 있으나 공부 시간에는 없다면, 해당 카테고리의 공부 시간은 0이다.
-     * @param studies 공부 시간 리스트
-     * @param categories 카테고리 리스트
-     * @return 공부시간과 카테고리를 합한 리스트
-     */
-    private List<GetStudyRes> toStudyResList(List<GetStudyDto> studies, List<GetCategoryRes> categories) {
-
-        // 공부 시간 리스트에서 카테고리에 대한 공부 시간을 추출
-        Map<Long, Long> timeByCategory = studies.stream()
-                .filter(s -> s.categoryId() != null)
-                .collect(Collectors.toMap(GetStudyDto::categoryId, GetStudyDto::time));
-
-        // 카테고리 리스트에서 방금 추출한 카테고리에 대한 공부 시간을 기반으로 매칭
-        List<GetStudyRes> result = categories.stream()
-                .map(category -> GetStudyRes.builder()
-                        .categoryId(category.categoryId())
-                        .name(category.name())
-                        .color(category.color())
-                        .description(category.description())
-                        .time(timeByCategory.getOrDefault(category.categoryId(), 0L))
-                        .build())
-                .toList();
-
-        // 공부 시간 리스트에서 카테고리가 아닌 임시 이름을 추출하여 저장
-        List<GetStudyRes> temporary = studies.stream()
-                .filter(s -> s.categoryId() == null && s.temporaryName() != null)
-                .map(s -> GetStudyRes.builder()
-                        .temporaryName(s.temporaryName())
-                        .time(s.time())
-                        .build())
-                .toList();
-
-        // 위 리스트를 합침
-        List<GetStudyRes> combined = new ArrayList<>(result);
-        combined.addAll(temporary);
-
-        return combined;
-    }
-
-    /**
-     * 두 리스트에서 값을 합쳐 반환한다.
-     * studies 는 특정 기간 동안 모든 카테고리(임시토픽) 당 공부 시간에 대한 정보이고, infos 는 특정 날짜의 시작/종료 시간 및 메모
-     * 에 대한 정보이다.
-     * 따라서, studies 로부터 공부 날짜와 그에 따른 공부 리스트를 map 으로 구성하여, 반환 시 이를 기반으로 공부 날짜를 매칭하여 반환
-     * @param studies 카테고리(임시토픽) 공부시간
-     * @param infos 하루의 정보
-     * @return 합친 것
-     */
-    private List<GetDailyStudyRes> toDailyStudyList(List<GetDailyStudyDto> studies, List<GetDailyStudyInfoDto> infos) {
-
-        Map<LocalDate, List<StudyList>> studyMap =
-                studies.stream().collect(Collectors.toMap(GetDailyStudyDto::studiedDate, GetDailyStudyDto::studyList));
+        Map<LocalDate, List<StudyList>> studyMap = dailyStudies.stream()
+                .collect(Collectors.toMap(GetDailyStudyDto::studiedDate, GetDailyStudyDto::studyList));
 
         return infos.stream()
                 .map(info -> GetDailyStudyRes.builder()

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/AbstractCategoryBasedStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/AbstractCategoryBasedStrategy.java
@@ -41,7 +41,7 @@ public abstract class AbstractCategoryBasedStrategy implements StudyRenderStrate
         // map의 id 인 typeId에 대하여 categories의 id와 매핑시킵니다. 만약 map에 존재하지 않으면 0이 들어갑니다.
         return categories.stream()
                 .map(c -> GetStudyRes.builder()
-                        .type(getType())
+                        .studyType(getType())
                         .typeId(c.typeId())
                         .name(c.name())
                         .color(c.color())

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/AbstractCategoryBasedStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/AbstractCategoryBasedStrategy.java
@@ -1,0 +1,53 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.studypals.domain.studyManage.dto.GetCategoryRes;
+import com.studypals.domain.studyManage.dto.GetStudyDto;
+import com.studypals.domain.studyManage.dto.GetStudyRes;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * {@code StudyRenderStrategy} 에 대한 추상 구현 클래스입니다. PERSONAL, GROUP 과 같은 종류의
+ * StudyType의 경우, 그 내부 로직이 동일한 경우에 대하여 공통 된 부분을 해당 객체에 정의합니다.
+ * <p>
+ * support 와 compose 메서드를 정의하였습니다. 이는 각각 팩토리 메서드에서 어떤 객체를 사용할 것인지를
+ * 판별하는 메서드와, 입력된 정보를 적절히 매핑하는 역할을 수행합니다.
+ * 각 메서드의 comment는 interface에 정의되어 있습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@code StudyRenderStrategy} 의 추상 클래스입니다.
+ *
+ * @author jack8
+ * @see StudyRenderStrategy
+ * @since 2025-05-06
+ */
+public abstract class AbstractCategoryBasedStrategy implements StudyRenderStrategy {
+
+    @Override
+    public boolean supports(StudyType type) {
+        return type == getType();
+    }
+
+    @Override
+    public List<GetStudyRes> compose(List<GetStudyDto> studies, List<GetCategoryRes> categories) {
+        // studies 를 typeId / time 으로 매핑하여 저장합니다.
+        Map<Long, Long> timeMap = studies.stream()
+                .filter(dto -> dto.type() == getType() && dto.typeId() != null)
+                .collect(Collectors.toMap(GetStudyDto::typeId, GetStudyDto::time));
+
+        // map의 id 인 typeId에 대하여 categories의 id와 매핑시킵니다. 만약 map에 존재하지 않으면 0이 들어갑니다.
+        return categories.stream()
+                .map(c -> GetStudyRes.builder()
+                        .type(getType())
+                        .typeId(c.typeId())
+                        .name(c.name())
+                        .color(c.color())
+                        .description(c.description())
+                        .time(timeMap.getOrDefault(c.typeId(), 0L))
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/AbstractCategoryBasedStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/AbstractCategoryBasedStrategy.java
@@ -35,7 +35,7 @@ public abstract class AbstractCategoryBasedStrategy implements StudyRenderStrate
     public List<GetStudyRes> compose(List<GetStudyDto> studies, List<GetCategoryRes> categories) {
         // studies 를 typeId / time 으로 매핑하여 저장합니다.
         Map<Long, Long> timeMap = studies.stream()
-                .filter(dto -> dto.type() == getType() && dto.typeId() != null)
+                .filter(dto -> dto.studyType() == getType() && dto.typeId() != null)
                 .collect(Collectors.toMap(GetStudyDto::typeId, GetStudyDto::time));
 
         // map의 id 인 typeId에 대하여 categories의 id와 매핑시킵니다. 만약 map에 존재하지 않으면 0이 들어갑니다.

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/GroupStudyCategoryRenderStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/GroupStudyCategoryRenderStrategy.java
@@ -1,0 +1,28 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType이 GROUP 인 studyTime 레코드에 대한 처리를 담당합니다.
+ * 공통된 메서드는 {@link AbstractCategoryBasedStrategy} 에 정의되어 있으며,
+ * 해당 객체가 담당하는 타입에 대한 getType 메서드만 정의하였습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * AbstractCategoryBasedStrategy 의 구현 클래스
+ *
+ * <p><b>빈 관리:</b><br>
+ * Component
+ *
+ * @author jack8
+ * @since 2025-05-06
+ */
+@Component
+public class GroupStudyCategoryRenderStrategy extends AbstractCategoryBasedStrategy {
+
+    @Override
+    public StudyType getType() {
+        return StudyType.GROUP;
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/PersonalCategoryStudyRenderStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/PersonalCategoryStudyRenderStrategy.java
@@ -1,0 +1,28 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType이 PERSONAL 인 studyTime 레코드에 대한 처리를 담당합니다.
+ * 공통된 메서드는 {@link AbstractCategoryBasedStrategy} 에 정의되어 있으며,
+ * 해당 객체가 담당하는 타입에 대한 getType 메서드만 정의하였습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * AbstractCategoryBasedStrategy 의 구현 클래스
+ *
+ * <p><b>빈 관리:</b><br>
+ * Component
+ *
+ * @author jack8
+ * @since 2025-05-06
+ */
+@Component
+public class PersonalCategoryStudyRenderStrategy extends AbstractCategoryBasedStrategy {
+
+    @Override
+    public StudyType getType() {
+        return StudyType.PERSONAL;
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategy.java
@@ -1,0 +1,41 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import java.util.List;
+
+import com.studypals.domain.studyManage.dto.GetCategoryRes;
+import com.studypals.domain.studyManage.dto.GetStudyDto;
+import com.studypals.domain.studyManage.dto.GetStudyRes;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType에 따른 StudyTime record에 대해 각 처리 방법을 전략 패턴에 위임하기 위해 사용되는,
+ * strategy 객체의 인터페이스입니다. 타입에 대한 정의, 객체의 호환성, 실제 작업 내용에 대한 메서드의 정의입니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * AbstractCategoryBasedStrategy 및 다른 구체 클래스의 부모 인터페이스
+ *
+ * @author jack8
+ * @see AbstractCategoryBasedStrategy
+ * @since 2025-05-06
+ */
+public interface StudyRenderStrategy {
+
+    StudyType getType();
+    /**
+     * {@code  StudyRenderStrategyFactory} 에서 List 주입된 객체들에 대하여, 어떤 객체를 반환할지 판별하기 위해
+     * 해당 메서드를 호출합니다.
+     * @param type StudyType의 값
+     * @return 해당 객체가, 해당 type을 지원하는지에 대한 여부
+     */
+    boolean supports(StudyType type);
+
+    /**
+     * studies와 categories 의 정보를 합칩니다. studies는 공부한 데이터가 들어가 있으며 categories는 해당
+     * 카테고리에 대한 정보가 포함되어 있습니다. studies에 포함된 카테고리 id 및 type을 기반으로,
+     * 적절한 카테고리 데이터를 매칭시켜 반환합니다.
+     * @param studies 공부 시간에 대한 정보. type, typeId, studyTime 등의 데이터
+     * @param categories 카테고리 정보. 특정 날짜에 대한 모든 카테고리 데이터가 포함되어 있습니다.
+     * @return 두 파라미터의 값을 id에 대해 매핑하여 합친 데이터
+     */
+    List<GetStudyRes> compose(List<GetStudyDto> studies, List<GetCategoryRes> categories);
+}

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategy.java
@@ -20,6 +20,10 @@ import com.studypals.domain.studyManage.entity.StudyType;
  */
 public interface StudyRenderStrategy {
 
+    /**
+     * studyType에 대한 정보를 반환합니다. 해당 전략 패턴이 지원하는 타입에 대한 정보입니다.
+     * @return 지원하는 StudyType 정보
+     */
     StudyType getType();
     /**
      * {@code  StudyRenderStrategyFactory} 에서 List 주입된 객체들에 대하여, 어떤 객체를 반환할지 판별하기 위해
@@ -30,12 +34,14 @@ public interface StudyRenderStrategy {
     boolean supports(StudyType type);
 
     /**
-     * studies와 categories 의 정보를 합칩니다. studies는 공부한 데이터가 들어가 있으며 categories는 해당
-     * 카테고리에 대한 정보가 포함되어 있습니다. studies에 포함된 카테고리 id 및 type을 기반으로,
-     * 적절한 카테고리 데이터를 매칭시켜 반환합니다.
-     * @param studies 공부 시간에 대한 정보. type, typeId, studyTime 등의 데이터
-     * @param categories 카테고리 정보. 특정 날짜에 대한 모든 카테고리 데이터가 포함되어 있습니다.
-     * @return 두 파라미터의 값을 id에 대해 매핑하여 합친 데이터
+     * studies와 categories의 정보를 합칩니다.
+     * studies는 공부한 데이터가 들어가 있으며, categories는 해당 카테고리에 대한 정보가 포함되어 있습니다.
+     * studies에 포함된 카테고리의 id 및 type을 기반으로, 적절한 카테고리 데이터를 매칭시켜 반환합니다.
+     *
+     * @param studies 공부 시간에 대한 정보 목록 (null이 될 수 없으며, 비어 있을 수는 있음)
+     * @param categories 카테고리 정보 목록 (null이 될 수 없으며, 비어 있을 수는 있음)
+     * @return 두 리스트를 id 기준으로 매핑하여 합친 데이터 목록. 일치하는 항목이 없으면 빈 리스트 반환.
+     * @throws NullPointerException studies 또는 categories가 null인 경우
      */
     List<GetStudyRes> compose(List<GetStudyDto> studies, List<GetCategoryRes> categories);
 }

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategyFactory.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategyFactory.java
@@ -1,0 +1,70 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.dto.GetCategoryRes;
+import com.studypals.domain.studyManage.dto.GetStudyDto;
+import com.studypals.domain.studyManage.dto.GetStudyRes;
+import com.studypals.domain.studyManage.entity.StudyType;
+import com.studypals.global.exceptions.errorCode.StudyErrorCode;
+import com.studypals.global.exceptions.exception.StudyException;
+
+/**
+ * StudyRenderStrategy 에 대한 팩토리 메서드를 정의합니다.
+ * <p>
+ * List로 주입받은 StudyRenderStrategy 의 자식 객체들에 대하여, 입력받은 데이터에 대해 적절한 객체를 반환하여 사용토록
+ * 합니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * Component 이며, StudyRenderStrategy 의 자식 객체를 DI에 의해 리스트로 주입받고 있습니다.
+ *
+ * @author jack8
+ * @since 2025-05-06
+ */
+@Component
+public class StudyRenderStrategyFactory {
+
+    private final List<StudyRenderStrategy> strategies;
+
+    /**
+     * 생성자를 통한 DI / 리스트 주입
+     * @param strategies DI에 의해 주입받는 StudyRenderStrategy 의 자식 객체들
+     */
+    public StudyRenderStrategyFactory(List<StudyRenderStrategy> strategies) {
+        this.strategies = strategies;
+    }
+
+    /**
+     * 여러 섞여 있는 공부 시간 데이터와(studies), StudyType에 의해 그룹화된 카테고리 데이터(infoByType)를
+     * 적절한 객체에 의해 적절한 값으로 변형되어 합쳐집니다.
+     * @param studies 공부 시간 데이터
+     * @param infoByType StudyType 과 카테고리 정보로 매핑된 데이터
+     * @return 정제된 데이터
+     */
+    public List<GetStudyRes> compose(List<GetStudyDto> studies, Map<StudyType, List<GetCategoryRes>> infoByType) {
+        return strategies.stream()
+                .flatMap(
+                        s -> { // 전력 패턴 상의 객체들을 펼침
+                            // 해당 전략 객체가 지원하는 StudyType을 검색
+                            StudyType type = Arrays.stream(StudyType.values())
+                                    .filter(s::supports)
+                                    .findFirst()
+                                    .orElseThrow(() -> new StudyException(
+                                            StudyErrorCode.STUDY_TIME_NOT_FOUND,
+                                            "maybe, StudyType value invalid so can't find strategy object"));
+                            // 위에서 찾은 type에 대해 studies에서 이를 찾고 리스트로 변환
+                            List<GetStudyDto> filtered = studies.stream()
+                                    .filter(d -> d.type() == type)
+                                    .toList();
+                            // infoByType에서 위에서 찾은 type(map의 id)를 검색/반환
+                            List<GetCategoryRes> categories = infoByType.getOrDefault(type, List.of());
+                            // 각 전략 객체의 compose를 호출/스트림으로 변환
+                            return s.compose(filtered, categories).stream();
+                        })
+                .toList();
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategyFactory.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/StudyRenderStrategyFactory.java
@@ -58,9 +58,9 @@ public class StudyRenderStrategyFactory {
                                             "maybe, StudyType value invalid so can't find strategy object"));
                             // 위에서 찾은 type에 대해 studies에서 이를 찾고 리스트로 변환
                             List<GetStudyDto> filtered = studies.stream()
-                                    .filter(d -> d.type() == type)
+                                    .filter(d -> d.studyType() == type)
                                     .toList();
-                            // infoByType에서 위에서 찾은 type(map의 id)를 검색/반환
+                            // infoByType에서 위에서 찾은 studyType(map의 id)를 검색/반환
                             List<GetCategoryRes> categories = infoByType.getOrDefault(type, List.of());
                             // 각 전략 객체의 compose를 호출/스트림으로 변환
                             return s.compose(filtered, categories).stream();

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/TemporarStudyRenderStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/TemporarStudyRenderStrategy.java
@@ -39,7 +39,7 @@ public class TemporarStudyRenderStrategy implements StudyRenderStrategy {
     public List<GetStudyRes> compose(List<GetStudyDto> studies, List<GetCategoryRes> unused) {
         return studies.stream()
                 .map(s -> GetStudyRes.builder()
-                        .type(getType())
+                        .studyType(getType())
                         .name(s.temporaryName())
                         .time(s.time())
                         .build())

--- a/src/main/java/com/studypals/domain/studyManage/facade/strategy/TemporarStudyRenderStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/facade/strategy/TemporarStudyRenderStrategy.java
@@ -1,0 +1,48 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.dto.GetCategoryRes;
+import com.studypals.domain.studyManage.dto.GetStudyDto;
+import com.studypals.domain.studyManage.dto.GetStudyRes;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType이 PERSONAL 인 studyTime 레코드에 대한 처리를 담당합니다.
+ * 다른 테이블과의 연관관계를 맺지 않으므로 인터페이스 자체를 상속받았습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * AbstractCategoryBasedStrategy 의 구현 클래스
+ *
+ * <p><b>빈 관리:</b><br>
+ * Component
+ *
+ * @author jack8
+ * @since 2025-05-06
+ */
+@Component
+public class TemporarStudyRenderStrategy implements StudyRenderStrategy {
+
+    @Override
+    public StudyType getType() {
+        return StudyType.TEMPORARY;
+    }
+
+    @Override
+    public boolean supports(StudyType type) {
+        return type == getType();
+    }
+
+    @Override
+    public List<GetStudyRes> compose(List<GetStudyDto> studies, List<GetCategoryRes> unused) {
+        return studies.stream()
+                .map(s -> GetStudyRes.builder()
+                        .type(getType())
+                        .name(s.temporaryName())
+                        .time(s.time())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/service/StudySessionServiceImpl.java
+++ b/src/main/java/com/studypals/domain/studyManage/service/StudySessionServiceImpl.java
@@ -92,7 +92,7 @@ public class StudySessionServiceImpl implements StudySessionService {
         // 2) DB에 공부시간 및 종료 시간 upsert
         Member member = memberReader.getRef(userId);
         studySessionWorker.upsert(member, status, today, durationInSec);
-        dailyInfoWriter.updateEndtime(userId, today, endTime);
+        dailyInfoWriter.updateEndtime(member, today, endTime);
 
         // 3) 레디스 상태 값 리셋
         status = studyStatusWorker.resetStatus(status, durationInSec);

--- a/src/main/java/com/studypals/domain/studyManage/service/StudySessionServiceImpl.java
+++ b/src/main/java/com/studypals/domain/studyManage/service/StudySessionServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.memberManage.worker.MemberReader;
 import com.studypals.domain.studyManage.dto.StartStudyReq;
 import com.studypals.domain.studyManage.dto.StartStudyRes;
 import com.studypals.domain.studyManage.dto.mappers.StudyTimeMapper;
@@ -55,13 +57,15 @@ public class StudySessionServiceImpl implements StudySessionService {
     private final StudySessionWorker studySessionWorker;
     private final StudyStatusWorker studyStatusWorker;
     private final DailyInfoWriter dailyInfoWriter;
+    private final MemberReader memberReader;
 
     @Override
     @Transactional
     public StartStudyRes startStudy(Long userId, StartStudyReq dto) {
 
+        Member member = memberReader.getRef(userId);
         // status 정보 가져오기 - 존재하지 않으면 최초 양식 생성
-        StudyStatus status = studyStatusWorker.find(userId).orElseGet(() -> studyStatusWorker.firstStatus(userId, dto));
+        StudyStatus status = studyStatusWorker.find(userId).orElseGet(() -> studyStatusWorker.firstStatus(member, dto));
 
         if (!status.isStudying()) {
             status = studyStatusWorker.restartStatus(status, dto);
@@ -86,7 +90,8 @@ public class StudySessionServiceImpl implements StudySessionService {
         Long durationInSec = getTimeDuration(status.getStartTime(), endTime);
 
         // 2) DB에 공부시간 및 종료 시간 upsert
-        studySessionWorker.upsert(userId, status, today, durationInSec);
+        Member member = memberReader.getRef(userId);
+        studySessionWorker.upsert(member, status, today, durationInSec);
         dailyInfoWriter.updateEndtime(userId, today, endTime);
 
         // 3) 레디스 상태 값 리셋
@@ -104,12 +109,12 @@ public class StudySessionServiceImpl implements StudySessionService {
      * @return 초 단위 공부 시간
      */
     private Long getTimeDuration(LocalTime start, LocalTime end) {
-        if (start.isAfter(end)) {
+        if (!start.isAfter(end)) {
             return Duration.between(start, end).toSeconds();
         }
 
         // startTime 이 00:00 전이고, endTime 이 이후인 경우
-        long startToMidnight = Duration.between(start, LocalTime.MIDNIGHT).toSeconds();
+        long startToMidnight = Duration.between(start, LocalTime.MAX).toSeconds() + 1L;
         long midnightToEnd = Duration.between(LocalTime.MIN, end).toSeconds();
         return startToMidnight + midnightToEnd;
     }

--- a/src/main/java/com/studypals/domain/studyManage/service/StudyTimeServiceImpl.java
+++ b/src/main/java/com/studypals/domain/studyManage/service/StudyTimeServiceImpl.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import com.studypals.domain.studyManage.dto.GetDailyStudyDto;
 import com.studypals.domain.studyManage.dto.GetStudyDto;
 import com.studypals.domain.studyManage.dto.PeriodDto;
-import com.studypals.domain.studyManage.dto.StudyList;
 import com.studypals.domain.studyManage.dto.mappers.StudyTimeMapper;
 import com.studypals.domain.studyManage.entity.StudyTime;
 import com.studypals.domain.studyManage.worker.StudyTimeReader;
@@ -47,7 +46,6 @@ public class StudyTimeServiceImpl implements StudyTimeService {
 
     private final TimeUtils timeUtils;
     private final StudyTimeMapper studyTimeMapper;
-
     private final StudyTimeReader studyTimeReader;
 
     @Override
@@ -73,14 +71,9 @@ public class StudyTimeServiceImpl implements StudyTimeService {
                 .entrySet()
                 .stream() // entry 로 변환
                 .map(entry -> new GetDailyStudyDto(
-                        entry.getKey(), // entry 의 키는 그룹화 한 기준
-                        entry.getValue().stream() // 값은 해당 객체
-                                .map(st -> new StudyList(
-                                        st.getCategory() != null // 카테고리가 null 이면 temporaryName 을 써야 하므로
-                                                ? st.getCategory().getId()
-                                                : null,
-                                        st.getTemporaryName(),
-                                        st.getTime()))
+                        entry.getKey(),
+                        entry.getValue().stream()
+                                .map(studyTimeMapper::toStudyDto)
                                 .toList()))
                 .sorted(Comparator.comparing(GetDailyStudyDto::studiedDate)) // 공부 날짜에 따라 정렬
                 .toList();

--- a/src/main/java/com/studypals/domain/studyManage/worker/DailyInfoWriter.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/DailyInfoWriter.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 
 import lombok.RequiredArgsConstructor;
 
+import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.studyManage.dao.DailyStudyInfoRepository;
 import com.studypals.domain.studyManage.entity.DailyStudyInfo;
 import com.studypals.global.annotations.Worker;
@@ -27,14 +28,15 @@ public class DailyInfoWriter {
      * daily info 엔티티에서 종료 시간을 최신화 합니다. 종료 시간은 가장 마지막에 종료되는 시각이므로, 최신화가 되어야 합니다.
      * 종료 시간이 들어가지 않아있는 경우, 아침 6시로 간주하여야 합니다.
      * <p> NOT TESTED / simple logic </p>
-     * @param userId 갱신할 user 의 id
+     * @param member 갱신할 user 의 엔티티
      * @param studiedDate 공부 날짜(검색을 위한)
      * @param endedAt 종료 시간(갱신을 위한)
      */
-    public void updateEndtime(Long userId, LocalDate studiedDate, LocalTime endedAt) {
+    public void updateEndtime(Member member, LocalDate studiedDate, LocalTime endedAt) {
         DailyStudyInfo summary = dailyStudyInfoRepository
-                .findByMemberIdAndStudiedDate(userId, studiedDate)
-                .orElseThrow(() -> new StudyException(StudyErrorCode.STUDY_TIME_END_FAIL));
+                .findByMemberIdAndStudiedDate(member.getId(), studiedDate)
+                .orElseThrow(() -> new StudyException(
+                        StudyErrorCode.STUDY_TIME_END_FAIL, "can't update end time in" + "[DailyInfoWriter]"));
 
         summary.setEndTime(endedAt);
     }

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
@@ -35,7 +35,7 @@ public class StudyCategoryReader {
     }
 
     /**
-     * 특정 날짜의, 해당 유저의 카테고리를 가져오는 메서드
+     * 특정 날짜의, 해당 유저의 카테고리를 가져오는 메서드. dayBelong이 0인 경우 주간 카테고리이므로 해당 데이터도 가져온다.
      * @param userId 검색할 유저의 아이디
      * @param dayBit 검색할 요일 / 비트 / 가령 수요일이면 0b0000100 (4) 로 정의
      * @return 카테고리 리스트
@@ -43,7 +43,8 @@ public class StudyCategoryReader {
     public List<StudyCategory> getListByMemberAndDay(Long userId, int dayBit) {
 
         return studyCategoryRepository.findByMemberId(userId).stream()
-                .filter(category -> (category.getDayBelong() & dayBit) != 0)
+                .filter(category -> ((category.getDayBelong() & dayBit) != 0)
+                        || category.getDayBelong().equals(0))
                 .toList();
     }
 

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
@@ -43,8 +43,7 @@ public class StudyCategoryReader {
     public List<StudyCategory> getListByMemberAndDay(Long userId, int dayBit) {
 
         return studyCategoryRepository.findByMemberId(userId).stream()
-                .filter(category -> ((category.getDayBelong() & dayBit) != 0)
-                        || category.getDayBelong().equals(0))
+                .filter(category -> ((category.getDayBelong() & dayBit) != 0) || category.getDayBelong() == 0)
                 .toList();
     }
 

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudySessionWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudySessionWorker.java
@@ -1,17 +1,15 @@
 package com.studypals.domain.studyManage.worker;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.memberManage.entity.Member;
-import com.studypals.domain.memberManage.worker.MemberReader;
-import com.studypals.domain.studyManage.dao.StudyCategoryRepository;
 import com.studypals.domain.studyManage.dao.StudyTimeRepository;
-import com.studypals.domain.studyManage.entity.StudyCategory;
 import com.studypals.domain.studyManage.entity.StudyStatus;
 import com.studypals.domain.studyManage.entity.StudyTime;
+import com.studypals.domain.studyManage.worker.strategy.StudyTimePersistenceStrategy;
+import com.studypals.domain.studyManage.worker.strategy.StudyTimePersistenceStrategyFactory;
 import com.studypals.global.annotations.Worker;
 import com.studypals.global.exceptions.errorCode.StudyErrorCode;
 import com.studypals.global.exceptions.exception.StudyException;
@@ -28,83 +26,24 @@ import com.studypals.global.exceptions.exception.StudyException;
 public class StudySessionWorker {
 
     private final StudyTimeRepository studyTimeRepository;
-    private final StudyCategoryRepository studyCategoryRepository;
-    private final MemberReader memberReader;
+    private final StudyTimePersistenceStrategyFactory strategyFactory;
 
     /**
      * studyTime 을 최신화하는 메서드. category에 대한 공부인지, temporaryName 에 대한 공부인지에 따라
      * 갈린다.
-     * @param userId 사용자 id
      * @param status redis 에 저장된 사용자 상태
      * @param studiedDate 언제 공부했는지에 대한 날짜(today)
      * @param time 초 단위 공부 시간
      */
-    public void upsert(Long userId, StudyStatus status, LocalDate studiedDate, Long time) {
+    public void upsert(Member member, StudyStatus status, LocalDate studiedDate, Long time) {
 
-        Long categoryId = status.getCategoryId();
-        String temporaryName = status.getTemporaryName();
-        Member member = memberReader.get(userId);
-
-        // member 에 토큰을 업데이트
         member.addToken(calculateToken(time));
 
-        if (categoryId != null) { // 카테고리에 대한 공부인 경우
-            Optional<StudyTime> optional =
-                    studyTimeRepository.findByMemberIdAndStudiedDateAndCategoryId(userId, studiedDate, categoryId);
-            if (optional.isPresent()) {
-                optional.get().addTime(time); // 이미 해당 레코드가 존재하면, 시간만 더해준다.
-            } else {
-                createWithCategory(member, categoryId, studiedDate, time); // 해당 레코드가 존재하지 않으면 새로 저장한다.
-            }
-        } else if (temporaryName != null) { // 임시 이름에 대한 공부인 경우
-            Optional<StudyTime> optional = studyTimeRepository.findByMemberIdAndStudiedDateAndTemporaryName(
-                    userId, studiedDate, temporaryName);
-            if (optional.isPresent()) {
-                optional.get().addTime(time); // 이미 존재하는 경우, 시간만 더해준다.
-            } else {
-                createWithTemporaryName(member, temporaryName, studiedDate, time); // 존재하지 않는 경우 새로 저장한다.
-            }
-        } else { // 모두 다 null 인 경우 실패
-            throw new StudyException(StudyErrorCode.STUDY_TIME_END_FAIL, "both id, name null in redis");
-        }
-    }
+        StudyTimePersistenceStrategy strategy = strategyFactory.resolve(status);
 
-    /**
-     * 카테고리에 대한 공부 일 시, 해당 메서드를 통해 studyTime 테이블에 데이터를 저장한다.
-     * @param member 사용자
-     * @param categoryId 카테고리 아이디
-     * @param studiedDate 공부 날짜(today)
-     * @param time 초 단위 공부 시간
-     */
-    public void createWithCategory(Member member, Long categoryId, LocalDate studiedDate, Long time) {
-        StudyCategory studyCategory = studyCategoryRepository.getReferenceById(categoryId);
-        StudyTime newStudyTime = StudyTime.builder()
-                .member(member)
-                .category(studyCategory)
-                .studiedDate(studiedDate)
-                .time(time)
-                .build();
-
-        saveTime(newStudyTime);
-    }
-
-    /**
-     * 임시 이름에 대한 공부 일 시, 해당 메서드를 통해 studyTime 테이블에 데이터를 저장한다.
-     * @param member 사용자
-     * @param temporaryName 임시 이름
-     * @param studiedDate 공부 날짜(today)
-     * @param time 초 단위 공부 시간
-     */
-    public void createWithTemporaryName(Member member, String temporaryName, LocalDate studiedDate, Long time) {
-
-        StudyTime newStudyTime = StudyTime.builder()
-                .member(member)
-                .temporaryName(temporaryName)
-                .studiedDate(studiedDate)
-                .time(time)
-                .build();
-
-        saveTime(newStudyTime);
+        strategy.find(member, status, studiedDate)
+                .ifPresentOrElse(
+                        st -> st.addTime(time), () -> saveTime(strategy.create(member, status, studiedDate, time)));
     }
 
     private void saveTime(StudyTime time) {

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudySessionWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudySessionWorker.java
@@ -24,11 +24,10 @@ import com.studypals.global.exceptions.exception.StudyException;
 @Worker
 @RequiredArgsConstructor
 public class StudySessionWorker {
+    private static final Long TOKEN_CALCULATE_VALUE = 60L;
 
     private final StudyTimeRepository studyTimeRepository;
     private final StudyTimePersistenceStrategyFactory strategyFactory;
-
-    private static final Long TOKEN_CALCULATE_VALUE = 60L;
 
     /**
      * studyTime 을 최신화하는 메서드. category에 대한 공부인지, temporaryName 에 대한 공부인지에 따라

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudySessionWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudySessionWorker.java
@@ -28,6 +28,8 @@ public class StudySessionWorker {
     private final StudyTimeRepository studyTimeRepository;
     private final StudyTimePersistenceStrategyFactory strategyFactory;
 
+    private static final Long TOKEN_CALCULATE_VALUE = 60L;
+
     /**
      * studyTime 을 최신화하는 메서드. category에 대한 공부인지, temporaryName 에 대한 공부인지에 따라
      * 갈린다.
@@ -55,6 +57,6 @@ public class StudySessionWorker {
     }
 
     private Long calculateToken(Long time) {
-        return time / 60; // 어떤 값이 올지 몰라서 일단 1분당 토큰 1개 / 나중에 확정되면 숫자를 따로 뺄 예정
+        return time / TOKEN_CALCULATE_VALUE;
     }
 }

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -67,7 +67,7 @@ public class StudyStatusWorker {
                 .id(member.getId())
                 .studying(true)
                 .startTime(dto.startTime())
-                .studyType(dto.type())
+                .studyType(dto.studyType())
                 .typeId(dto.typeId())
                 .temporaryName(dto.temporaryName())
                 .build();
@@ -98,7 +98,7 @@ public class StudyStatusWorker {
         return status.update()
                 .studying(true)
                 .startTime(dto.startTime())
-                .studyType(dto.type())
+                .studyType(dto.studyType())
                 .typeId(dto.typeId())
                 .temporaryName(dto.temporaryName())
                 .build();

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -35,6 +35,11 @@ public class StudyStatusWorker {
     private final DailyStudyInfoRepository dailyStudyInfoRepository;
     private final TimeUtils timeUtils;
 
+    /**
+     * id에 대하여 studyStatus 를 redis로 부터 검색합니다.
+     * @param id 검색하고자 하는 studyStatus의 id 이자, user의 id
+     * @return Optional - study status
+     */
     public Optional<StudyStatus> find(Long id) {
         return studyStatusRedisRepository.findById(id);
     }
@@ -55,10 +60,9 @@ public class StudyStatusWorker {
         try {
             dailyStudyInfoRepository.save(summary);
         } catch (Exception e) {
-            throw new StudyException(StudyErrorCode.STUDY_TIME_START_FAIL);
+            throw new StudyException(StudyErrorCode.STUDY_TIME_START_FAIL, "fail to create daily study info");
         }
 
-        // todo : mapper class 로 이동?
         return StudyStatus.builder()
                 .id(member.getId())
                 .studying(true)

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
-import com.studypals.domain.memberManage.worker.MemberReader;
+import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.studyManage.dao.DailyStudyInfoRepository;
 import com.studypals.domain.studyManage.dao.StudyStatusRedisRepository;
 import com.studypals.domain.studyManage.dto.StartStudyReq;
@@ -33,7 +33,6 @@ public class StudyStatusWorker {
 
     private final StudyStatusRedisRepository studyStatusRedisRepository;
     private final DailyStudyInfoRepository dailyStudyInfoRepository;
-    private final MemberReader memberReader;
     private final TimeUtils timeUtils;
 
     public Optional<StudyStatus> find(Long id) {
@@ -41,15 +40,14 @@ public class StudyStatusWorker {
     }
 
     /**
-     * 처음 공부 시작 시 객체를 생성한다.
-     * @param userId 사용자의 id
+     * 처음 공부 시작 시 객체를 생성합니다. 추가로, DailyStudyInfo를 생성하고 추가합니다.
      * @param dto 공부 데이터
      * @return 만들어진 객체
      */
-    public StudyStatus firstStatus(Long userId, StartStudyReq dto) {
+    public StudyStatus firstStatus(Member member, StartStudyReq dto) {
 
         DailyStudyInfo summary = DailyStudyInfo.builder()
-                .member(memberReader.get(userId))
+                .member(member)
                 .studiedDate(timeUtils.getToday())
                 .startTime(dto.startTime())
                 .build();
@@ -60,11 +58,13 @@ public class StudyStatusWorker {
             throw new StudyException(StudyErrorCode.STUDY_TIME_START_FAIL);
         }
 
+        // todo : mapper class 로 이동?
         return StudyStatus.builder()
-                .id(userId)
+                .id(member.getId())
                 .studying(true)
                 .startTime(dto.startTime())
-                .categoryId(dto.categoryId())
+                .studyType(dto.type())
+                .typeId(dto.typeId())
                 .temporaryName(dto.temporaryName())
                 .build();
     }
@@ -79,7 +79,8 @@ public class StudyStatusWorker {
                 .studyTime(status.getStudyTime() + studiedTimeToAdd)
                 .studying(false)
                 .startTime(null)
-                .categoryId(null)
+                .studyType(null)
+                .typeId(null)
                 .temporaryName(null)
                 .build();
     }
@@ -93,7 +94,8 @@ public class StudyStatusWorker {
         return status.update()
                 .studying(true)
                 .startTime(dto.startTime())
-                .categoryId(dto.categoryId())
+                .studyType(dto.type())
+                .typeId(dto.typeId())
                 .temporaryName(dto.temporaryName())
                 .build();
     }
@@ -124,7 +126,8 @@ public class StudyStatusWorker {
         StudyStatus updated = status.update()
                 .studying(false)
                 .startTime(null)
-                .categoryId(null)
+                .studyType(null)
+                .typeId(null)
                 .temporaryName(null)
                 .build();
 

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/AbstractStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/AbstractStudyPersistenceStrategy.java
@@ -1,0 +1,47 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.studyManage.dao.StudyTimeRepository;
+import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.domain.studyManage.entity.StudyTime;
+
+/**
+ * StudyTimePersistenceStrategy 인터페이스의 추상 클래스입니다. 일부 전략 객체의 공통된 부분을 정의합니다.
+ *
+ * @author jack8
+ * @see StudyTimePersistenceStrategy
+ * @since 2025-05-06
+ */
+public abstract class AbstractStudyPersistenceStrategy implements StudyTimePersistenceStrategy {
+
+    protected final StudyTimeRepository studyTimeRepository;
+
+    protected AbstractStudyPersistenceStrategy(StudyTimeRepository studyTimeRepository) {
+        this.studyTimeRepository = studyTimeRepository;
+    }
+
+    @Override
+    public boolean supports(StudyStatus status) {
+        return status.getStudyType() == getType() && status.getTypeId() != null;
+    }
+
+    @Override
+    public Optional<StudyTime> find(Member member, StudyStatus status, LocalDate studiedDate) {
+        return studyTimeRepository.findByMemberIdAndStudiedDateAndStudyTypeAndTypeId(
+                member.getId(), studiedDate, getType(), status.getTypeId());
+    }
+
+    @Override
+    public StudyTime create(Member member, StudyStatus status, LocalDate studiedDate, Long time) {
+        return StudyTime.builder()
+                .member(member)
+                .studyType(getType())
+                .typeId(status.getTypeId())
+                .studiedDate(studiedDate)
+                .time(time)
+                .build();
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/AbstractStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/AbstractStudyPersistenceStrategy.java
@@ -30,8 +30,7 @@ public abstract class AbstractStudyPersistenceStrategy implements StudyTimePersi
 
     @Override
     public Optional<StudyTime> find(Member member, StudyStatus status, LocalDate studiedDate) {
-        return studyTimeRepository.findByMemberIdAndStudiedDateAndStudyTypeAndTypeId(
-                member.getId(), studiedDate, getType(), status.getTypeId());
+        return studyTimeRepository.findByStudyType(member.getId(), studiedDate, getType(), status.getTypeId());
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/AbstractStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/AbstractStudyPersistenceStrategy.java
@@ -30,7 +30,8 @@ public abstract class AbstractStudyPersistenceStrategy implements StudyTimePersi
 
     @Override
     public Optional<StudyTime> find(Member member, StudyStatus status, LocalDate studiedDate) {
-        return studyTimeRepository.findByStudyType(member.getId(), studiedDate, getType(), status.getTypeId());
+        return studyTimeRepository.findByStudyType(
+                member.getId(), studiedDate, getType().name(), status.getTypeId());
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/GroupStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/GroupStudyPersistenceStrategy.java
@@ -1,0 +1,29 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.dao.StudyTimeRepository;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType이 GROUP 인 레코드에 대해, 검색/생성 및 전략 패턴에서의 호환성 여부를 정의합니다.
+ * 다만, 이는 AbstractStudyPersistenceStrategy 추상 클래스의 구현 클래스이며, 추상 클래스에 공통된 부분에 대한 메서드가
+ * 정의되어 있습니다. 따라서 해당 객체에서는 StudyType만 정의하였습니다.
+ *
+ * @author jack8
+ * @see AbstractStudyPersistenceStrategy
+ * @see StudyTimePersistenceStrategy
+ * @since 2025-05-06
+ */
+@Component
+public class GroupStudyPersistenceStrategy extends AbstractStudyPersistenceStrategy {
+
+    public GroupStudyPersistenceStrategy(StudyTimeRepository studyTimeRepository) {
+        super(studyTimeRepository);
+    }
+
+    @Override
+    public StudyType getType() {
+        return StudyType.GROUP;
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/PersonalStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/PersonalStudyPersistenceStrategy.java
@@ -1,0 +1,29 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.dao.StudyTimeRepository;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType이 PERSONAL 인 레코드에 대해, 검색/생성 및 전략 패턴에서의 호환성 여부를 정의합니다.
+ * 다만, 이는 AbstractStudyPersistenceStrategy 추상 클래스의 구현 클래스이며, 추상 클래스에 공통된 부분에 대한 메서드가
+ * 정의되어 있습니다. 따라서 해당 객체에서는 StudyType만 정의하였습니다.
+ *
+ * @author jack8
+ * @see AbstractStudyPersistenceStrategy
+ * @see StudyTimePersistenceStrategy
+ * @since 2025-05-06
+ */
+@Component
+public class PersonalStudyPersistenceStrategy extends AbstractStudyPersistenceStrategy {
+
+    public PersonalStudyPersistenceStrategy(StudyTimeRepository studyTimeRepository) {
+        super(studyTimeRepository);
+    }
+
+    @Override
+    public StudyType getType() {
+        return StudyType.PERSONAL;
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/StudyTimePersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/StudyTimePersistenceStrategy.java
@@ -1,0 +1,57 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.domain.studyManage.entity.StudyTime;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyTIme 엔티티에 대해, 각기 다른 저장/조회 로직을 정의하기 위해 사용되는 전략패턴의 인터페이스입니다.
+ * 모든 전략 객체는 해당 인터페이스를 부모로 두어야 합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * AbstractStudyPersistenceStrategy 및 다른 구체 클래스의 부모 인터페이스
+ *
+ * @author jack8
+ * @see AbstractStudyPersistenceStrategy
+ * @since 2025-05-06
+ */
+public interface StudyTimePersistenceStrategy {
+
+    /**
+     * 각 전략 객체의 호환되는 타입을 정의합니다.
+     * @return 해당 전략 객체가 지원하는 StudyType
+     */
+    StudyType getType();
+
+    /**
+     * 각 전략 객체가 StudyStatus에 대해 자신이 이를 지원하는지에 대한 여부를 반환합니다. 팩토리에서 이를 통해
+     * StudyStatus에 대응하는 전략 객체를 호출합니다.
+     * @param status 공부 상태(redis에 저장되는) 를 받아 전략 객체 호환 여부 체크
+     * @return 호환 여부
+     */
+    boolean supports(StudyStatus status);
+
+    /**
+     * 주어진 매개변수를 통하여 적절한 엔티티를 탐색하여 반환합니다. 직접적인 repository를 사용함으로서 transaction
+     * 이 필수적으로 포함되어야 합니다.
+     * @param member 검색하고자 하는 member
+     * @param status 공부 상태
+     * @param studiedDate 공부 날짜
+     * @return 검색된 StudyTime의 Optional 래핑
+     */
+    Optional<StudyTime> find(Member member, StudyStatus status, LocalDate studiedDate);
+
+    /**
+     * 주어진 매개변수를 통하여 새로운 StudyTime을 생성하여 반환합니다. 엔티티를 저장하지 않고 반환함합니다.
+     * @param member 만들고자 하는 member
+     * @param status 새로운 status
+     * @param studiedDate 공부한 날짜
+     * @param time 공부한 시간
+     * @return 생성된 StudyTime 비영속 엔티티
+     */
+    StudyTime create(Member member, StudyStatus status, LocalDate studiedDate, Long time);
+}

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/StudyTimePersistenceStrategyFactory.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/StudyTimePersistenceStrategyFactory.java
@@ -1,0 +1,39 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.global.exceptions.errorCode.StudyErrorCode;
+import com.studypals.global.exceptions.exception.StudyException;
+
+/**
+ * StudyTime 객체의 전략 패턴의 팩토리 객체입니다. 클라이언트는 해당 객체를 이용하여 적절한 전략 객체에게
+ * 그 처리를 위임하여야 합니다.
+ *
+ * @author jack8
+ * @since 2025-05-06
+ */
+@Component
+public class StudyTimePersistenceStrategyFactory {
+
+    private final List<StudyTimePersistenceStrategy> strategies;
+
+    public StudyTimePersistenceStrategyFactory(List<StudyTimePersistenceStrategy> strategies) {
+        this.strategies = strategies;
+    }
+
+    /**
+     * StudyStatus로부터 StudyType을 추출하여, 올바른 전략 객체를 반환합니다. 클라이언트는 해당 메서드를 사용하여
+     * 적절하게 반환받은 StudyTImePersistenceStrategy 의 자식 객체를 이용하여 로직을 수행하여야 합니다.
+     * @param status 전략 객체를 고르기 위한 매개변수
+     * @return status에 따른 적절한 전략 객체
+     */
+    public StudyTimePersistenceStrategy resolve(StudyStatus status) {
+        return strategies.stream()
+                .filter(s -> s.supports(status))
+                .findFirst()
+                .orElseThrow(() -> new StudyException(StudyErrorCode.STUDY_TIME_NOT_FOUND, "not supported strategy"));
+    }
+}

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/TemporarStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/TemporarStudyPersistenceStrategy.java
@@ -40,8 +40,7 @@ public class TemporarStudyPersistenceStrategy implements StudyTimePersistenceStr
 
     @Override
     public Optional<StudyTime> find(Member member, StudyStatus status, LocalDate studiedDate) {
-        return studyTimeRepository.findByMemberIdAndStudiedDateAndTemporaryName(
-                member.getId(), studiedDate, status.getTemporaryName());
+        return studyTimeRepository.findByTemporaryName(member.getId(), studiedDate, status.getTemporaryName());
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/studyManage/worker/strategy/TemporarStudyPersistenceStrategy.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/strategy/TemporarStudyPersistenceStrategy.java
@@ -1,0 +1,57 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.studyManage.dao.StudyTimeRepository;
+import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.domain.studyManage.entity.StudyTime;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * StudyType이 TEMPORARY 인 레코드에 대해, 검색/생성 및 전략 패턴에서의 호환성 여부를 정의합니다.
+ *
+ *
+ * @author jack8
+ * @see AbstractStudyPersistenceStrategy
+ * @see StudyTimePersistenceStrategy
+ * @since 2025-05-06
+ */
+@Component
+@RequiredArgsConstructor
+public class TemporarStudyPersistenceStrategy implements StudyTimePersistenceStrategy {
+
+    private final StudyTimeRepository studyTimeRepository;
+
+    @Override
+    public StudyType getType() {
+        return StudyType.TEMPORARY;
+    }
+
+    @Override
+    public boolean supports(StudyStatus status) {
+        return status.getStudyType() == getType() && status.getTemporaryName() != null;
+    }
+
+    @Override
+    public Optional<StudyTime> find(Member member, StudyStatus status, LocalDate studiedDate) {
+        return studyTimeRepository.findByMemberIdAndStudiedDateAndTemporaryName(
+                member.getId(), studiedDate, status.getTemporaryName());
+    }
+
+    @Override
+    public StudyTime create(Member member, StudyStatus status, LocalDate studiedDate, Long time) {
+        return StudyTime.builder()
+                .member(member)
+                .studyType(getType())
+                .temporaryName(status.getTemporaryName())
+                .studiedDate(studiedDate)
+                .time(time)
+                .build();
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/DefaultExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/DefaultExceptionHandler.java
@@ -88,13 +88,13 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleHttpMediaTypeNotSupported(
             HttpMediaTypeNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        return fail("ERE-01", "Unsupported media type", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        return fail("ERE-01", "Unsupported media studyType", HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     }
 
     @Override
     protected ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(
             HttpMediaTypeNotAcceptableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        return fail("ERE-02", "Not acceptable media type", HttpStatus.NOT_ACCEPTABLE);
+        return fail("ERE-02", "Not acceptable media studyType", HttpStatus.NOT_ACCEPTABLE);
     }
 
     @Override
@@ -145,7 +145,7 @@ public class DefaultExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleTypeMismatch(
             TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        return fail("ERE-10", "Parameter type mismatch", HttpStatus.BAD_REQUEST);
+        return fail("ERE-10", "Parameter studyType mismatch", HttpStatus.BAD_REQUEST);
     }
 
     // EVD - 검증 실패

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -12,7 +12,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 
 #logging.level.org.hibernate.SQL=DEBUG
-#logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+#logging.level.org.hibernate.studyType.descriptor.sql.BasicBinder=TRACE
 
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}

--- a/src/test/java/com/studypals/domain/studyManage/dto/mappers/CategoryMapperTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/dto/mappers/CategoryMapperTest.java
@@ -8,7 +8,6 @@ import org.mapstruct.factory.Mappers;
 
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.studyManage.dto.CreateCategoryReq;
-import com.studypals.domain.studyManage.dto.GetCategoryRes;
 import com.studypals.domain.studyManage.entity.StudyCategory;
 
 /**
@@ -40,28 +39,28 @@ class CategoryMapperTest {
         assertThat(entity.getMember().getId()).isEqualTo(1L);
     }
 
-    @Test
-    @DisplayName("StudyCategory → GetCategoryRes 매핑 성공")
-    void toDto_success() {
-        // given
-        Member member = Member.builder().id(2L).build();
-        StudyCategory entity = StudyCategory.builder()
-                .id(10L)
-                .name("CS")
-                .color("#CCCCCC")
-                .dayBelong(7)
-                .description("CS 공부용 카테고리")
-                .member(member)
-                .build();
-
-        // when
-        GetCategoryRes dto = mapper.toDto(entity);
-
-        // then
-        assertThat(dto.categoryId()).isEqualTo(10L);
-        assertThat(dto.name()).isEqualTo("CS");
-        assertThat(dto.color()).isEqualTo("#CCCCCC");
-        assertThat(dto.dayBelong()).isEqualTo(7);
-        assertThat(dto.description()).isEqualTo("CS 공부용 카테고리");
-    }
+    //    @Test
+    //    @DisplayName("StudyCategory → GetCategoryRes 매핑 성공")
+    //    void toDto_success() {
+    //        // given
+    //        Member member = Member.builder().id(2L).build();
+    //        StudyCategory entity = StudyCategory.builder()
+    //                .id(10L)
+    //                .name("CS")
+    //                .color("#CCCCCC")
+    //                .dayBelong(7)
+    //                .description("CS 공부용 카테고리")
+    //                .member(member)
+    //                .build();
+    //
+    //        // when
+    //        GetCategoryRes dto = mapper.toDto(entity);
+    //
+    //        // then
+    //        assertThat(dto.categoryId()).isEqualTo(10L);
+    //        assertThat(dto.name()).isEqualTo("CS");
+    //        assertThat(dto.color()).isEqualTo("#CCCCCC");
+    //        assertThat(dto.dayBelong()).isEqualTo(7);
+    //        assertThat(dto.description()).isEqualTo("CS 공부용 카테고리");
+    //    }
 }

--- a/src/test/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapperTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapperTest.java
@@ -33,7 +33,7 @@ class StudyTimeMapperTest {
                 .id(1L)
                 .studyTime(100L)
                 .startTime(LocalTime.of(10, 30))
-                .categoryId(5L)
+                .typeId(5L)
                 .temporaryName("temp")
                 .build();
 
@@ -44,7 +44,7 @@ class StudyTimeMapperTest {
         assertThat(dto.studying()).isTrue();
         assertThat(dto.startTime()).isEqualTo(LocalTime.of(10, 30));
         assertThat(dto.studyTime()).isEqualTo(100L);
-        assertThat(dto.categoryId()).isEqualTo(5L);
+        assertThat(dto.typeId()).isEqualTo(5L);
         assertThat(dto.temporaryName()).isEqualTo("temp");
     }
 
@@ -57,7 +57,6 @@ class StudyTimeMapperTest {
 
         StudyTime studyTime = StudyTime.builder()
                 .id(1L)
-                .category(category)
                 .temporaryName("temp")
                 .studiedDate(LocalDate.of(2024, 1, 1))
                 .time(80L)
@@ -68,7 +67,6 @@ class StudyTimeMapperTest {
         GetStudyDto dto = mapper.toDto(studyTime);
 
         // then
-        assertThat(dto.categoryId()).isEqualTo(7L);
         assertThat(dto.temporaryName()).isEqualTo("temp");
         assertThat(dto.time()).isEqualTo(80L);
     }

--- a/src/test/java/com/studypals/domain/studyManage/facade/StudyTimeFacadeTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/facade/StudyTimeFacadeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,10 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.studypals.domain.studyManage.dto.GetCategoryRes;
-import com.studypals.domain.studyManage.dto.GetStudyDto;
-import com.studypals.domain.studyManage.dto.GetStudyRes;
-import com.studypals.domain.studyManage.service.StudyCategoryService;
+import com.studypals.domain.studyManage.dto.*;
+import com.studypals.domain.studyManage.entity.StudyType;
+import com.studypals.domain.studyManage.service.DailyStudyInfoService;
 import com.studypals.domain.studyManage.service.StudyTimeService;
 
 /**
@@ -32,104 +32,49 @@ class StudyTimeFacadeTest {
     private StudyTimeService studyTimeService;
 
     @Mock
-    private StudyCategoryService studyCategoryService;
+    private DailyStudyInfoService dailyStudyInfoService;
 
     @InjectMocks
     private StudyTimeFacade studyTimeFacade;
 
-    private final Long userId = 1L;
-    private final LocalDate date = LocalDate.of(2025, 4, 16);
-
     @Test
-    void getStudyTimeByDate_success_withCategoryAndTemp() {
+    void getDailyStudyTimeByPeriod_success() {
         // given
-        List<GetStudyDto> studyList = List.of(new GetStudyDto(100L, null, 60L), new GetStudyDto(null, "임시공부", 45L));
+        Long userId = 1L;
+        PeriodDto period = new PeriodDto(LocalDate.of(2025, 5, 1), LocalDate.of(2025, 5, 3));
 
-        List<GetCategoryRes> categoryList = List.of(GetCategoryRes.builder()
-                .categoryId(100L)
-                .name("수학")
-                .color("#123456")
-                .dayBelong(12)
-                .description("수학 공부")
-                .build());
+        GetDailyStudyDto study1 = new GetDailyStudyDto(
+                LocalDate.of(2025, 5, 1), List.of(new StudyList(StudyType.PERSONAL, 100L, null, 60L)));
 
-        given(studyTimeService.getStudyList(userId, date)).willReturn(studyList);
-        given(studyCategoryService.getUserCategoryByDate(userId, date)).willReturn(categoryList);
+        GetDailyStudyDto study2 = new GetDailyStudyDto(
+                LocalDate.of(2025, 5, 2), List.of(new StudyList(StudyType.PERSONAL, 101L, null, 30L)));
+
+        GetDailyStudyInfoDto info1 =
+                new GetDailyStudyInfoDto(LocalDate.of(2025, 5, 1), LocalTime.of(8, 0), LocalTime.of(10, 0), "공부 열심히 함");
+
+        GetDailyStudyInfoDto info2 =
+                new GetDailyStudyInfoDto(LocalDate.of(2025, 5, 2), LocalTime.of(9, 0), LocalTime.of(11, 0), "적당히 함");
+
+        List<GetDailyStudyDto> studyList = List.of(study1, study2);
+        List<GetDailyStudyInfoDto> infoList = List.of(info1, info2);
+
+        given(studyTimeService.getDailyStudyList(userId, period)).willReturn(studyList);
+        given(dailyStudyInfoService.getDailyStudyInfoList(userId, period)).willReturn(infoList);
 
         // when
-        List<GetStudyRes> result = studyTimeFacade.getStudyTimeByDate(userId, date);
+        List<GetDailyStudyRes> result = studyTimeFacade.getDailyStudyTimeByPeriod(userId, period);
 
         // then
         assertThat(result).hasSize(2);
 
-        GetStudyRes categoryStudy =
-                result.stream().filter(r -> r.categoryId() != null).findFirst().orElseThrow();
-        assertThat(categoryStudy.time()).isEqualTo(60L);
-        assertThat(categoryStudy.name()).isEqualTo("수학");
+        GetDailyStudyRes res1 = result.get(0);
+        assertThat(res1.studiedDate()).isEqualTo(LocalDate.of(2025, 5, 1));
+        assertThat(res1.studies()).hasSize(1);
+        assertThat(res1.memo()).isEqualTo("공부 열심히 함");
 
-        GetStudyRes tempStudy = result.stream()
-                .filter(r -> r.temporaryName() != null)
-                .findFirst()
-                .orElseThrow();
-        assertThat(tempStudy.temporaryName()).isEqualTo("임시공부");
-        assertThat(tempStudy.time()).isEqualTo(45L);
-    }
-
-    @Test
-    void getStudyTimeByDate_success_onlyCategory() {
-        // given
-        List<GetStudyDto> studyList = List.of(new GetStudyDto(100L, null, 120L));
-
-        List<GetCategoryRes> categoryList = List.of(GetCategoryRes.builder()
-                .categoryId(100L)
-                .name("영어")
-                .color("#000000")
-                .dayBelong(10)
-                .description("영어 공부")
-                .build());
-
-        given(studyTimeService.getStudyList(userId, date)).willReturn(studyList);
-        given(studyCategoryService.getUserCategoryByDate(userId, date)).willReturn(categoryList);
-
-        // when
-        List<GetStudyRes> result = studyTimeFacade.getStudyTimeByDate(userId, date);
-
-        // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).categoryId()).isEqualTo(100L);
-        assertThat(result.get(0).temporaryName()).isNull();
-        assertThat(result.get(0).time()).isEqualTo(120L);
-    }
-
-    @Test
-    void getStudyTimeByDate_success_onlyTemp() {
-        // given
-        List<GetStudyDto> studyList = List.of(new GetStudyDto(null, "기타", 90L));
-
-        List<GetCategoryRes> categoryList = List.of();
-
-        given(studyTimeService.getStudyList(userId, date)).willReturn(studyList);
-        given(studyCategoryService.getUserCategoryByDate(userId, date)).willReturn(categoryList);
-
-        // when
-        List<GetStudyRes> result = studyTimeFacade.getStudyTimeByDate(userId, date);
-
-        // then
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).temporaryName()).isEqualTo("기타");
-        assertThat(result.get(0).time()).isEqualTo(90L);
-    }
-
-    @Test
-    void getStudyTimeByDate_success_emptyAll() {
-        // given
-        given(studyTimeService.getStudyList(userId, date)).willReturn(List.of());
-        given(studyCategoryService.getUserCategoryByDate(userId, date)).willReturn(List.of());
-
-        // when
-        List<GetStudyRes> result = studyTimeFacade.getStudyTimeByDate(userId, date);
-
-        // then
-        assertThat(result).isEmpty();
+        GetDailyStudyRes res2 = result.get(1);
+        assertThat(res2.studiedDate()).isEqualTo(LocalDate.of(2025, 5, 2));
+        assertThat(res2.studies()).hasSize(1);
+        assertThat(res2.memo()).isEqualTo("적당히 함");
     }
 }

--- a/src/test/java/com/studypals/domain/studyManage/facade/strategy/CategoryBasedStrategyTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/facade/strategy/CategoryBasedStrategyTest.java
@@ -1,0 +1,90 @@
+package com.studypals.domain.studyManage.facade.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.studypals.domain.studyManage.dto.GetCategoryRes;
+import com.studypals.domain.studyManage.dto.GetStudyDto;
+import com.studypals.domain.studyManage.dto.GetStudyRes;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * {@link AbstractCategoryBasedStrategy} 를 상속받는 비슷한 로직의 객체들에 대한 단위 테스트
+ *
+ * @author jack8
+ * @see AbstractCategoryBasedStrategy
+ * @see GroupStudyCategoryRenderStrategy
+ * @see PersonalCategoryStudyRenderStrategy
+ * @since 2025-05-07
+ */
+@ExtendWith({MockitoExtension.class})
+class CategoryBasedStrategyTest {
+
+    private final PersonalCategoryStudyRenderStrategy strategy = new PersonalCategoryStudyRenderStrategy();
+
+    @Test
+    void compose_success_matched() {
+        // given
+        List<GetStudyDto> studies = List.of(
+                new GetStudyDto(StudyType.PERSONAL, 1L, null, 60L), // PERSONAL
+                new GetStudyDto(StudyType.PERSONAL, 2L, null, 40L));
+
+        List<GetCategoryRes> categories = List.of(
+                GetCategoryRes.builder()
+                        .typeId(1L)
+                        .name("수학")
+                        .color("#000000")
+                        .description("수학 공부")
+                        .build(),
+                GetCategoryRes.builder()
+                        .typeId(2L)
+                        .name("영어")
+                        .color("#111111")
+                        .description("영어 공부")
+                        .build());
+
+        // when
+        List<GetStudyRes> result = strategy.compose(studies, categories);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        assertThat(result).anySatisfy(res -> {
+            assertThat(res.typeId()).isEqualTo(1L);
+            assertThat(res.name()).isEqualTo("수학");
+            assertThat(res.time()).isEqualTo(60L);
+        });
+
+        assertThat(result).anySatisfy(res -> {
+            assertThat(res.typeId()).isEqualTo(2L);
+            assertThat(res.name()).isEqualTo("영어");
+            assertThat(res.time()).isEqualTo(40L);
+        });
+    }
+
+    @Test
+    void compose_success_nonStudied() {
+        // given
+        List<GetStudyDto> studies = List.of(); // 아무 기록도 없음
+
+        List<GetCategoryRes> categories = List.of(GetCategoryRes.builder()
+                .typeId(10L)
+                .name("물리")
+                .color("#FF0000")
+                .description("물리 공부")
+                .build());
+
+        // when
+        List<GetStudyRes> result = strategy.compose(studies, categories);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).typeId()).isEqualTo(10L);
+        assertThat(result.get(0).time()).isEqualTo(0L);
+    }
+}

--- a/src/test/java/com/studypals/domain/studyManage/restDocsTest/CategoryControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/restDocsTest/CategoryControllerRestDocsTest.java
@@ -27,6 +27,7 @@ import com.studypals.domain.studyManage.api.CategoryController;
 import com.studypals.domain.studyManage.dto.CreateCategoryReq;
 import com.studypals.domain.studyManage.dto.GetCategoryRes;
 import com.studypals.domain.studyManage.dto.UpdateCategoryReq;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.domain.studyManage.service.StudyCategoryService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
@@ -139,8 +140,8 @@ class CategoryControllerRestDocsTest extends RestDocsSupport {
     void read_success() throws Exception {
         // given
         List<GetCategoryRes> list = List.of(
-                new GetCategoryRes(1L, "백엔드", "#FFAA00", 12, "Spring 공부"),
-                new GetCategoryRes(2L, "알고리즘", "#00CCFF", 14, "문제풀이"));
+                new GetCategoryRes(StudyType.PERSONAL, 1L, "백준", "#FFAA00", 12, "Spring 공부"),
+                new GetCategoryRes(StudyType.PERSONAL, 2L, "알고리즘", "#00CCFF", 14, "문제풀이"));
         Response<List<GetCategoryRes>> expected = CommonResponse.success(ResponseCode.STUDY_CATEGORY_LIST, list);
 
         given(studyCategoryService.getUserCategory(any())).willReturn(list);
@@ -155,7 +156,8 @@ class CategoryControllerRestDocsTest extends RestDocsSupport {
                         httpRequest(),
                         httpResponse(),
                         responseFields(
-                                fieldWithPath("data[].categoryId").description("카테고리 ID"),
+                                fieldWithPath("data[].studyType").description("카테고리 테이블 정보(타입)"),
+                                fieldWithPath("data[].typeId").description("연관 테이블 타입 ID"),
                                 fieldWithPath("data[].name").description("카테고리 이름"),
                                 fieldWithPath("data[].color").description("색상 코드"),
                                 fieldWithPath("data[].dayBelong").description("요일 소속값"),

--- a/src/test/java/com/studypals/domain/studyManage/restDocsTest/StudySessionControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/restDocsTest/StudySessionControllerRestDocsTest.java
@@ -22,6 +22,7 @@ import com.studypals.domain.studyManage.api.StudySessionController;
 import com.studypals.domain.studyManage.dto.EndStudyReq;
 import com.studypals.domain.studyManage.dto.StartStudyReq;
 import com.studypals.domain.studyManage.dto.StartStudyRes;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.domain.studyManage.service.StudySessionService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
@@ -44,9 +45,9 @@ class StudySessionControllerRestDocsTest extends RestDocsSupport {
     @WithMockUser
     void start_success_withCategoryId() throws Exception {
         // given
-        StartStudyReq req = new StartStudyReq(1L, null, LocalTime.of(10, 0));
+        StartStudyReq req = new StartStudyReq(StudyType.PERSONAL, 1L, null, LocalTime.of(10, 0));
 
-        StartStudyRes res = new StartStudyRes(true, LocalTime.of(10, 0, 0), 0L, 1L, null);
+        StartStudyRes res = new StartStudyRes(true, LocalTime.of(10, 0, 0), 0L, StudyType.PERSONAL, null, "some name");
         Response<StartStudyRes> expected = CommonResponse.success(ResponseCode.STUDY_START, res, "success start");
 
         given(studySessionService.startStudy(any(), any())).willReturn(res);
@@ -63,8 +64,11 @@ class StudySessionControllerRestDocsTest extends RestDocsSupport {
                         httpRequest(),
                         httpResponse(),
                         requestFields(
-                                fieldWithPath("categoryId")
-                                        .description("카테고리 ID")
+                                fieldWithPath("studyType")
+                                        .description("공부 유형 타입 정의")
+                                        .attributes(constraints("GROUP / PERSONAL / TEMPORARY 허용")),
+                                fieldWithPath("typeId")
+                                        .description("연관된 테이블의 레코드 ID")
                                         .attributes(constraints("temporaryName과 상호 베타적")),
                                 fieldWithPath("temporaryName")
                                         .description("임시 카테고리 이름")
@@ -77,7 +81,8 @@ class StudySessionControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.studying").description("공부 중 여부"),
                                 fieldWithPath("data.startTime").description("공부 시작 시간"),
                                 fieldWithPath("data.studyTime").description("현재까지 누적 공부 시간"),
-                                fieldWithPath("data.categoryId").description("카테고리 ID"),
+                                fieldWithPath("data.studyType").description("공부 유형 타입"),
+                                fieldWithPath("data.typeId").description("공부 유형 타입 ID"),
                                 fieldWithPath("data.temporaryName").description("임시 카테고리 이름"))));
     }
 

--- a/src/test/java/com/studypals/domain/studyManage/restDocsTest/StudyTimeControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/restDocsTest/StudyTimeControllerRestDocsTest.java
@@ -5,9 +5,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.http.HttpDocumentation.httpRequest;
 import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
@@ -25,6 +27,7 @@ import com.studypals.domain.studyManage.api.StudyTimeController;
 import com.studypals.domain.studyManage.dto.GetDailyStudyRes;
 import com.studypals.domain.studyManage.dto.GetStudyRes;
 import com.studypals.domain.studyManage.dto.StudyList;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.domain.studyManage.facade.StudyTimeFacade;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
@@ -45,21 +48,25 @@ class StudyTimeControllerRestDocsTest extends RestDocsSupport {
 
         List<GetStudyRes> response = List.of(
                 GetStudyRes.builder()
-                        .categoryId(1L)
+                        .studyType(StudyType.PERSONAL)
+                        .typeId(1L)
                         .name("자바")
                         .color("#FFCC00")
                         .description("자바 공부")
                         .time(120L)
                         .build(),
                 GetStudyRes.builder()
-                        .categoryId(null)
-                        .name(null)
+                        .studyType(StudyType.TEMPORARY)
                         .color(null)
                         .description(null)
-                        .temporaryName("백준 공부")
+                        .name("백준 공부")
                         .time(500L)
                         .build(),
-                GetStudyRes.builder().temporaryName("임시 카테고리").time(60L).build());
+                GetStudyRes.builder()
+                        .studyType(StudyType.TEMPORARY)
+                        .name("임시 카테고리")
+                        .time(60L)
+                        .build());
 
         Response<List<GetStudyRes>> expected =
                 CommonResponse.success(ResponseCode.STUDY_TIME_PARTIAL, response, "data of date");
@@ -82,14 +89,15 @@ class StudyTimeControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("status").description("응답 상태"),
                                 fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data[].categoryId")
-                                        .description("카테고리 ID")
+                                fieldWithPath("data[].studyType").description("타입 종류"),
+                                fieldWithPath("data[].typeId")
+                                        .description("해당 타입의 id")
                                         .optional(),
                                 fieldWithPath("data[].name")
                                         .description("카테고리 이름")
                                         .optional(),
-                                fieldWithPath("data[].temporaryName")
-                                        .description("임시 카테고리 이름")
+                                fieldWithPath("data[].name")
+                                        .description("카테고리 이름 / 혹은 TEMPORARY 시 임시 카테고리 이름")
                                         .optional(),
                                 fieldWithPath("data[].color")
                                         .description("카테고리 색상")
@@ -110,7 +118,9 @@ class StudyTimeControllerRestDocsTest extends RestDocsSupport {
                         .startTime(LocalTime.of(9, 0))
                         .endTime(LocalTime.of(11, 0))
                         .memo("집중 잘 됨")
-                        .studies(List.of(new StudyList(null, "알고리즘", 60L), new StudyList(2L, null, 30L)))
+                        .studies(List.of(
+                                new StudyList(StudyType.TEMPORARY, null, "알고리즘", 60L),
+                                new StudyList(StudyType.PERSONAL, 2L, null, 30L)))
                         .build(),
                 GetDailyStudyRes.builder()
                         .studiedDate(LocalDate.of(2024, 4, 3))
@@ -118,9 +128,9 @@ class StudyTimeControllerRestDocsTest extends RestDocsSupport {
                         .endTime(LocalTime.of(13, 0))
                         .memo("집중 잘 됨")
                         .studies(List.of(
-                                new StudyList(1L, null, 60L),
-                                new StudyList(2L, null, 30L),
-                                new StudyList(null, "토익", 30L)))
+                                new StudyList(StudyType.PERSONAL, 1L, null, 60L),
+                                new StudyList(StudyType.PERSONAL, 2L, null, 30L),
+                                new StudyList(StudyType.TEMPORARY, null, "토익", 30L)))
                         .build());
 
         Response<List<GetDailyStudyRes>> expectedResponse =
@@ -151,8 +161,9 @@ class StudyTimeControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data[].startTime").description("해당 날짜 공부 시작 시간"),
                                 fieldWithPath("data[].endTime").description("해당 날짜 공부 종료 시간"),
                                 fieldWithPath("data[].memo").description("간단한 메모"),
-                                fieldWithPath("data[].studies[].categoryId")
-                                        .description("카테고리 ID (없으면 null)")
+                                fieldWithPath("data[].studies[].studyType").description("타입 종류"),
+                                fieldWithPath("data[].studies[].typeId")
+                                        .description("해당 타입의 ID (없으면 null)")
                                         .optional(),
                                 fieldWithPath("data[].studies[].temporaryName")
                                         .description("임시 카테고리 이름 (없으면 null)")

--- a/src/test/java/com/studypals/domain/studyManage/service/DailyStudyInfoServiceTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/service/DailyStudyInfoServiceTest.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.studyManage.service;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -10,4 +11,5 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @since 2025-04-20
  */
 @ExtendWith(MockitoExtension.class)
+@Disabled("간단한 dao 메서드 대응. 테스트 생략")
 class DailyStudyInfoServiceTest {}

--- a/src/test/java/com/studypals/domain/studyManage/service/StudyCategoryServiceTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/service/StudyCategoryServiceTest.java
@@ -20,6 +20,7 @@ import com.studypals.domain.studyManage.dto.GetCategoryRes;
 import com.studypals.domain.studyManage.dto.UpdateCategoryReq;
 import com.studypals.domain.studyManage.dto.mappers.CategoryMapper;
 import com.studypals.domain.studyManage.entity.StudyCategory;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.domain.studyManage.worker.StudyCategoryReader;
 import com.studypals.domain.studyManage.worker.StudyCategoryWriter;
 import com.studypals.global.exceptions.errorCode.StudyErrorCode;
@@ -94,7 +95,7 @@ class StudyCategoryServiceTest {
     void getUserCategory_success() {
         // given
         Long userId = 1L;
-        GetCategoryRes res = new GetCategoryRes(1L, "category", "#FFFFFF", 12, "description");
+        GetCategoryRes res = new GetCategoryRes(StudyType.PERSONAL, 1L, "category", "#FFFFFF", 12, "description");
         given(studyCategoryReader.findByMember(userId)).willReturn(List.of(mockStudyCategory));
         given(categoryMapper.toDto(mockStudyCategory)).willReturn(res);
 
@@ -131,8 +132,9 @@ class StudyCategoryServiceTest {
         StudyCategory cat2 =
                 StudyCategory.builder().dayBelong(dayBit | (1 << 4)).build();
 
-        GetCategoryRes res1 = new GetCategoryRes(1L, "category1", "#FFF", dayBit, "desc1");
-        GetCategoryRes res2 = new GetCategoryRes(2L, "category2", "#000", dayBit | (1 << 4), "desc2");
+        GetCategoryRes res1 = new GetCategoryRes(StudyType.PERSONAL, 1L, "category1", "#FFF", dayBit, "desc1");
+        GetCategoryRes res2 =
+                new GetCategoryRes(StudyType.PERSONAL, 2L, "category2", "#000", dayBit | (1 << 4), "desc2");
 
         given(studyCategoryReader.getListByMemberAndDay(userId, dayBit)).willReturn(List.of(cat1, cat2));
         given(categoryMapper.toDto(cat1)).willReturn(res1);

--- a/src/test/java/com/studypals/domain/studyManage/service/StudyTimeServiceTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/service/StudyTimeServiceTest.java
@@ -19,6 +19,7 @@ import com.studypals.domain.studyManage.dto.GetStudyDto;
 import com.studypals.domain.studyManage.dto.PeriodDto;
 import com.studypals.domain.studyManage.dto.mappers.StudyTimeMapper;
 import com.studypals.domain.studyManage.entity.StudyTime;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.domain.studyManage.worker.StudyTimeReader;
 import com.studypals.global.utils.TimeUtils;
 
@@ -77,7 +78,7 @@ class StudyTimeServiceTest {
         // given
         Long userId = 1L;
         LocalDate today = LocalDate.of(2025, 4, 14);
-        GetStudyDto dto = new GetStudyDto(1L, null, 3600L);
+        GetStudyDto dto = new GetStudyDto(StudyType.PERSONAL, 1L, null, 3600L);
 
         given(timeUtils.getToday()).willReturn(today);
         given(studyTimeReader.getListByMemberAndDate(userId, today)).willReturn(List.of(mockStudyTime));

--- a/src/test/java/com/studypals/domain/studyManage/worker/DailyInfoReaderTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/DailyInfoReaderTest.java
@@ -1,0 +1,15 @@
+package com.studypals.domain.studyManage.worker;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link DailyInfoReader} 에 대한 테스트코드
+ *
+ * @author jack8
+ * @since 2025-05-07
+ */
+@Disabled("단순 DAO 메서드만 존재/ 테스트 생략")
+@ExtendWith(MockitoExtension.class)
+class DailyInfoReaderTest {}

--- a/src/test/java/com/studypals/domain/studyManage/worker/DailyInfoWriterTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/DailyInfoWriterTest.java
@@ -1,0 +1,58 @@
+package com.studypals.domain.studyManage.worker;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.studyManage.dao.DailyStudyInfoRepository;
+import com.studypals.domain.studyManage.entity.DailyStudyInfo;
+
+/**
+ * {@link DailyInfoWriter} 에 대한 테스트
+ *
+ * @author jack8
+ * @since 2025-05-07
+ */
+@ExtendWith(MockitoExtension.class)
+class DailyInfoWriterTest {
+
+    @Mock
+    private DailyStudyInfoRepository dailyStudyInfoRepository;
+
+    @Mock
+    private Member mockMember;
+
+    @Mock
+    private DailyStudyInfo mockDailyStudyInfo;
+
+    @InjectMocks
+    private DailyInfoWriter dailyInfoWriter;
+
+    @Test
+    void updateEndTime_success() {
+        // given
+        Long userId = 1L;
+        LocalDate date = LocalDate.of(2024, 3, 1);
+        LocalTime endTime = LocalTime.of(12, 0, 0);
+
+        given(mockMember.getId()).willReturn(userId);
+        given(dailyStudyInfoRepository.findByMemberIdAndStudiedDate(userId, date))
+                .willReturn(Optional.of(mockDailyStudyInfo));
+
+        // when
+        dailyInfoWriter.updateEndtime(mockMember, date, endTime);
+
+        // then
+        then(mockDailyStudyInfo).should().setEndTime(endTime);
+    }
+}

--- a/src/test/java/com/studypals/domain/studyManage/worker/StudyCategoryReaderTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/StudyCategoryReaderTest.java
@@ -57,6 +57,23 @@ class StudyCategoryReaderTest {
     }
 
     @Test
+    void getListByMemberAndDay_success_weeklyPlanReturn() {
+        // given
+        Long userId = 1L;
+        int dayBit = 0b0100; // 수요일만 선택된 비트
+        given(mockCategory1.getDayBelong()).willReturn(0b0110); // 화, 수 포함
+        given(mockCategory2.getDayBelong()).willReturn(0b0000000); // 주간 플랜
+
+        given(studyCategoryRepository.findByMemberId(userId)).willReturn(List.of(mockCategory1, mockCategory2));
+
+        // when
+        List<StudyCategory> result = studyCategoryReader.getListByMemberAndDay(userId, dayBit);
+
+        // then
+        assertThat(result).containsExactlyInAnyOrder(mockCategory1, mockCategory2);
+    }
+
+    @Test
     void getAndValidate_fail_notOwner() {
         // given
         Long userId = 1L;

--- a/src/test/java/com/studypals/domain/studyManage/worker/StudyCategoryWriterTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/StudyCategoryWriterTest.java
@@ -1,0 +1,19 @@
+package com.studypals.domain.studyManage.worker;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link StudyCategoryWriter} 에 대한 테스트 코드
+ *
+ * @author jack8
+ * @since 2025-05-07
+ */
+@Disabled("DAO 단순 호출 테스트 - 테스트 생략")
+@ExtendWith(MockitoExtension.class)
+class StudyCategoryWriterTest {
+
+    // may not need test becuase method is just simple dao method.
+
+}

--- a/src/test/java/com/studypals/domain/studyManage/worker/StudyStatusWorkerTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/StudyStatusWorkerTest.java
@@ -18,6 +18,7 @@ import com.studypals.domain.studyManage.dao.DailyStudyInfoRepository;
 import com.studypals.domain.studyManage.dao.StudyStatusRedisRepository;
 import com.studypals.domain.studyManage.dto.StartStudyReq;
 import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.global.exceptions.errorCode.StudyErrorCode;
 import com.studypals.global.exceptions.exception.StudyException;
 import com.studypals.global.utils.TimeUtils;
@@ -75,17 +76,17 @@ class StudyStatusWorkerTest {
         // given
         Long userId = 1L;
         LocalDate today = LocalDate.of(2025, 1, 1);
-        StartStudyReq req = new StartStudyReq(100L, null, LocalTime.of(9, 30));
-        given(memberReader.get(userId)).willReturn(mockMember);
+        StartStudyReq req = new StartStudyReq(StudyType.PERSONAL, 1L, null, LocalTime.of(9, 30));
         given(timeUtils.getToday()).willReturn(today);
+        given(mockMember.getId()).willReturn(userId);
 
         // when
-        StudyStatus result = studyStatusWorker.firstStatus(userId, req);
+        StudyStatus result = studyStatusWorker.firstStatus(mockMember, req);
 
         // then
         assertThat(result.getId()).isEqualTo(userId);
         assertThat(result.getStartTime()).isEqualTo(req.startTime());
-        assertThat(result.getCategoryId()).isEqualTo(req.categoryId());
+        assertThat(result.getTypeId()).isEqualTo(req.typeId());
         assertThat(result.getTemporaryName()).isEqualTo(req.temporaryName());
         assertThat(result.isStudying()).isTrue();
     }
@@ -96,7 +97,7 @@ class StudyStatusWorkerTest {
         StudyStatus original = StudyStatus.builder()
                 .id(1L)
                 .studyTime(100L)
-                .categoryId(10L)
+                .studyType(StudyType.TEMPORARY)
                 .temporaryName("test")
                 .startTime(LocalTime.of(10, 0))
                 .studying(true)
@@ -108,7 +109,6 @@ class StudyStatusWorkerTest {
         // then
         assertThat(updated.isStudying()).isFalse();
         assertThat(updated.getStudyTime()).isEqualTo(300L);
-        assertThat(updated.getCategoryId()).isNull();
         assertThat(updated.getTemporaryName()).isNull();
         assertThat(updated.getStartTime()).isNull();
     }
@@ -116,7 +116,7 @@ class StudyStatusWorkerTest {
     @Test
     void restartStatus_success() {
         // given
-        StartStudyReq req = new StartStudyReq(null, "focus", LocalTime.of(9, 30));
+        StartStudyReq req = new StartStudyReq(StudyType.TEMPORARY, null, "focus", LocalTime.of(9, 30));
         StudyStatus current =
                 StudyStatus.builder().id(1L).studyTime(120L).studying(false).build();
 
@@ -126,7 +126,7 @@ class StudyStatusWorkerTest {
         // then
         assertThat(restarted.isStudying()).isTrue();
         assertThat(restarted.getStartTime()).isEqualTo(req.startTime());
-        assertThat(restarted.getCategoryId()).isNull();
+        assertThat(restarted.getTypeId()).isNull();
         assertThat(restarted.getTemporaryName()).isEqualTo("focus");
     }
 

--- a/src/test/java/com/studypals/domain/studyManage/worker/strategy/CategoryBaseStudyPersistenceStrategyTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/strategy/CategoryBaseStudyPersistenceStrategyTest.java
@@ -1,0 +1,89 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.studyManage.dao.StudyTimeRepository;
+import com.studypals.domain.studyManage.entity.StudyStatus;
+import com.studypals.domain.studyManage.entity.StudyTime;
+import com.studypals.domain.studyManage.entity.StudyType;
+
+/**
+ * AbstractStudyPersistenceStrategy 를 상속받은 전략 객체에 대한 테스트 코드입니다.
+ * 현재 GROUP 과 PERSONAL 의 로직이 동일하므로 PERSONAL 을 사용하여 테스트를 진행합니다.
+ *
+ * @author jack8
+ * @see PersonalStudyPersistenceStrategy
+ * @see GroupStudyPersistenceStrategy
+ * @see AbstractStudyPersistenceStrategy
+ * @since 2025-05-07
+ */
+@ExtendWith(MockitoExtension.class)
+class CategoryBaseStudyPersistenceStrategyTest {
+
+    @Mock
+    private StudyTimeRepository studyTimeRepository;
+
+    @Mock
+    private Member mockMember;
+
+    @Mock
+    private StudyStatus mockStatus;
+
+    @Mock
+    private StudyTime mockStudyTime;
+
+    @InjectMocks
+    private PersonalStudyPersistenceStrategy personalStudyPersistenceStrategy;
+
+    @Test
+    void supports_success() {
+        // given
+        given(mockStatus.getStudyType()).willReturn(StudyType.PERSONAL);
+
+        // when
+        boolean result = personalStudyPersistenceStrategy.supports(mockStatus);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void supports_fail() {
+        // given
+        given(mockStatus.getStudyType()).willReturn(StudyType.GROUP);
+
+        // when
+        boolean result = personalStudyPersistenceStrategy.supports(mockStatus);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void find_success() {
+        // given
+        Long id = 1L;
+        LocalDate date = LocalDate.of(2024, 3, 1);
+        given(mockMember.getId()).willReturn(id);
+        given(mockStatus.getTypeId()).willReturn(100L);
+        given(studyTimeRepository.findByStudyType(id, date, "PERSONAL", 100L)).willReturn(Optional.of(mockStudyTime));
+
+        // when
+        Optional<StudyTime> result = personalStudyPersistenceStrategy.find(mockMember, mockStatus, date);
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get()).isEqualTo(mockStudyTime);
+    }
+}

--- a/src/test/java/com/studypals/domain/studyManage/worker/strategy/StudyTimePersistenceStrategyFactoryTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/strategy/StudyTimePersistenceStrategyFactoryTest.java
@@ -1,0 +1,78 @@
+package com.studypals.domain.studyManage.worker.strategy;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import com.studypals.domain.studyManage.entity.StudyStatus;
+
+/**
+ * {@link StudyTimePersistenceStrategyFactory} 에 대한 테스트 코드
+ * 전략 패턴에 의하여 전략 객체가 정상적으로 매핑되는지에 대한 테스트
+ *
+ * @author jack8
+ * @since 2025-05-07
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StudyTimePersistenceStrategyFactoryTest {
+
+    @Mock
+    PersonalStudyPersistenceStrategy personalStrategy;
+
+    @Mock
+    GroupStudyPersistenceStrategy groupStrategy;
+
+    @Mock
+    TemporarStudyPersistenceStrategy temporarStrategy;
+
+    @Mock
+    StudyStatus personalStatus;
+
+    @Mock
+    StudyStatus groupStatus;
+
+    @Mock
+    StudyStatus temporarStatus;
+
+    @InjectMocks
+    StudyTimePersistenceStrategyFactory strategyFactory;
+
+    @BeforeEach
+    void setUp() {
+        given(personalStrategy.supports(personalStatus)).willReturn(true);
+        given(groupStrategy.supports(groupStatus)).willReturn(true);
+        given(temporarStrategy.supports(temporarStatus)).willReturn(true);
+
+        strategyFactory =
+                new StudyTimePersistenceStrategyFactory(List.of(personalStrategy, groupStrategy, temporarStrategy));
+    }
+
+    @Test
+    void resolve_returnsPersonalStrategy() {
+        StudyTimePersistenceStrategy resolved = strategyFactory.resolve(personalStatus);
+        assertThat(resolved).isEqualTo(personalStrategy);
+    }
+
+    @Test
+    void resolve_returnsGroupStrategy() {
+        StudyTimePersistenceStrategy resolved = strategyFactory.resolve(groupStatus);
+        assertThat(resolved).isEqualTo(groupStrategy);
+    }
+
+    @Test
+    void resolve_returnsCompanyStrategy() {
+        StudyTimePersistenceStrategy resolved = strategyFactory.resolve(temporarStatus);
+        assertThat(resolved).isEqualTo(temporarStrategy);
+    }
+}

--- a/src/test/java/com/studypals/integrationTest/StudySessionIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/StudySessionIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.studyManage.dto.EndStudyReq;
 import com.studypals.domain.studyManage.dto.StartStudyReq;
+import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.global.responses.ResponseCode;
 import com.studypals.testModules.testSupport.IntegrationSupport;
 
@@ -34,7 +35,7 @@ public class StudySessionIntegrationTest extends IntegrationSupport {
     void startStudy_success_withCategoryId() throws Exception {
         // given
         CreateUserVar user = createUser();
-        StartStudyReq req = new StartStudyReq(1L, null, LocalTime.of(9, 0));
+        StartStudyReq req = new StartStudyReq(StudyType.PERSONAL, 1L, null, LocalTime.of(9, 0));
 
         // when
         ResultActions result = mockMvc.perform(post("/studies/sessions/start")
@@ -49,7 +50,8 @@ public class StudySessionIntegrationTest extends IntegrationSupport {
                 .andExpect(jsonPath("$.data.studying").value(true))
                 .andExpect(jsonPath("$.data.startTime").exists())
                 .andExpect(jsonPath("$.data.studyTime").value(0))
-                .andExpect(jsonPath("$.data.categoryId").value(1));
+                .andExpect(jsonPath("$.data.studyType").value("PERSONAL"))
+                .andExpect(jsonPath("$.data.typeId").value(1));
     }
 
     @Test
@@ -59,7 +61,7 @@ public class StudySessionIntegrationTest extends IntegrationSupport {
         CreateUserVar user = createUser();
 
         // 공부 시작
-        StartStudyReq startReq = new StartStudyReq(null, "name", LocalTime.of(9, 0));
+        StartStudyReq startReq = new StartStudyReq(StudyType.TEMPORARY, null, "name", LocalTime.of(9, 0));
         ResultActions result = mockMvc.perform(post("/studies/sessions/start")
                 .header("Authorization", "Bearer " + user.getAccessToken())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/studypals/integrationTest/StudyTimeIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/StudyTimeIntegrationTest.java
@@ -50,10 +50,11 @@ public class StudyTimeIntegrationTest extends IntegrationSupport {
 
         jdbcTemplate.update(
                 """
-                INSERT INTO study_time (id, category_id, member_id, time, studied_at)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO study_time (id, study_type, type_id, member_id, time, studied_date)
+                VALUES (?, ?, ?, ?, ?, ?)
     """,
                 1L,
+                "PERSONAL",
                 1L,
                 user.getUserId(),
                 120L,
@@ -68,7 +69,7 @@ public class StudyTimeIntegrationTest extends IntegrationSupport {
         // then
         result.andExpect(status().isOk())
                 .andExpect(hasKey("code", ResponseCode.STUDY_TIME_PARTIAL.getCode()))
-                .andExpect(jsonPath("$.data[0].categoryId").value(1L))
+                .andExpect(jsonPath("$.data[0].typeId").value(1L))
                 .andExpect(jsonPath("$.data[0].name").value("자바"))
                 .andExpect(jsonPath("$.data[0].time").value(120L));
     }
@@ -98,10 +99,11 @@ public class StudyTimeIntegrationTest extends IntegrationSupport {
         // study_time (카테고리 기반)
         jdbcTemplate.update(
                 """
-                INSERT INTO study_time (id, category_id, member_id, time, studied_at)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO study_time (id, study_type, type_id, member_id, time, studied_date)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 1L,
+                "PERSONAL",
                 100L,
                 userId,
                 60L,
@@ -110,10 +112,11 @@ public class StudyTimeIntegrationTest extends IntegrationSupport {
         // study_time (임시이름 기반)
         jdbcTemplate.update(
                 """
-                INSERT INTO study_time (id, temporary_name, member_id, time, studied_at)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO study_time (id, study_type,  temporary_name, member_id, time, studied_date)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 2L,
+                "TEMPORARY",
                 "토익",
                 userId,
                 90L,


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #76

## ✨ 구현 기능 명세

## 1. 엔티티의 변화  ( +dto)

`StudyTime`  및 `StudyStatus` 는 기존의 `categoryId` 를 대신하여 다음과 같은 필드가 존재합니다.

- `StudyType` , `typeId`

이는, 해당 레코드가 어떤 테이블과 관계를 맺는지에 대한 정보를 가지고 있으며 이는 `StudyType` 에 정의가 되어 있습니다

```java
public enum StudyType {
    PERSONAL,
    GROUP,
    TEMPORARY
}
```

- Personal 은 개인이 직접 설정한 카테고리에 대한 정의입니다.
- GROUP은 그룹에 의해 생성된 카테고리에 대한 정의입니다.
- TEMPORARY 는 임시 토픽에 대한 정의입니다

대부분의 entity 와 dto는 `studyType(type)`, `typeId` , `temporaryName`  필드가 존재합니다. typeId 는 type 이 PERSONAL, GROUP 인 경우, temporaryName 은 type 이 TEMPORARY 인 경우 사용됩니다.

## 2. DAO

- StudyCategoryRepository 에서

`findAllByIdInAndMemberId` 메서드는 `Set<Long> id` 와 `memberId` 를 인자로 받아서 id 들에 대한 엔티티를 반환합니다. memberId 를 넣은 까닭은 , 각 레코드가 해당 member가 생성한 것이 맞는지에 대한 검증을 포함시킵니다.

- StudyTimeRepository 에서

`findByMemberIdAndStudiedDateAndStudiedTypeAndTypeId` 는 명시된 인자로 엔티티를 Optional 로 반환합니다.
`findByMemberIdAndStudiedDateAndTemporaryName` 는 명시된 인자로 엔티티를 Optional 로 반환합니다.

## 3. worker

기본적으로 전략패턴이 포함됩니다. `StudyTimeStrategyFactory` 에서 `resolve` 메서드는 `StudyStatus` 를 매개변수로 받아 내부의 `StudyType` 을 이용하여 적절한 `StudyTimeStrategy` 인터페이스의 구현체를 반환합니다.

- StudySessionWorker 에서

해당 메서드는 공부가 종료된 후 해당 정보를 영속화 할 때 사용하는 메서드입니다 .따라서, redis 에 저장된 studyStatus 를 받아, 이로부터 타입(StudyType)을 추출하여, 적절한 조치를 취합니다.

- StudyCategoryReader 에서

`findAllByMemberAndIds` 는 id 들에 따른 엔티티 리스트를 반환하는 메서드입니다.

- strategies 에서

`GroupStudyPersistenceStrategy` 및 `PersonalStudyPersistenceStrategy` 는 StudyType 이 GROUP, PERSONAL 인 경우 사용되며,  겹치는 부분이 많기 때문에, 이에 대해 `StudyTimePersistenceStrategy`  의 구현 추상 클래스인 `AbstractStudyPersistenceStrategy` 에서 find 및 create 를 정의하였고, 각각에 대해 support, getType 메서드만 정의하였습니다.

## 4. facade

이 역시도 전략패턴을 사용하였습니다. 다음과 같은 역할을 수행합니다

- 해당 날짜에 대한 id 들을 추출. (만약 group cateogry가 추가되면, 이 역시도 가져와야 한다)
    - 즉, 만약 studyType이 PERSONAL, GROUP 등이 존재한다면, PERONAL, Set<Long> map 을 생성
- 여러 ID 들에 대해 해당하는 카테고리 정보를 받아, 결과를 매핑
    - 즉, 공부에 대한 정보를 담은 studies 와 여러 카테고리에 대한 정보를 담은 `Map<StudyType, Map<Long, GetCategoryRes>> infoByType` 이 있을 때, id 들을 매칭하여 적절한 category 정보와 매핑시킴

- 생각 포인트: 전략 패턴에게 카테고리 정보를 검색하는 것 또한 위임이 가능. 다만 장단점 존재
    - 만약 검색을 위임한다 → 새로운 studyType이 추가될 때마다 Facade에 검색→ 검색한 카테고리 정보를 다시 전략 객체에 넣어주는 행위를 생략 가능 / 유지보수성 증가    ///   다만 전략 패턴에게 너무 많은 책임이 가해짐. 단순히 데이터의 처리/정제만을 위해서 만든 패턴이 데이터 검색 까지 담당하게 됨.

---
# 현재 일단 PR을 작성하긴 하였으나 문서화/테스트 진행이 완료되지 않았습니다. 
올려주는 까닭은, ai 리뷰 및 추적을 위해서이며, 비지니스 로직 부분은 거의 끝난거 같으니(테스트 중 자잘자잘한 수정은 제외하고), 추후 작업하실 때, 해당 브랜치로부터 따서 진행하시면 될 것 같습니다(혹은 참고)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Convert the `study_time` table to use an `id-type` model and implement the strategy pattern for handling different `StudyType` entities.

### Why are these changes being made?

This update was necessary to implement a more flexible architecture by employing the strategy pattern, which allows for different handling of study types (`PERSONAL`, `GROUP`, `TEMPORARY`). By creating `StudyType` enums and associated strategies, the code management for various study records is improved. The change ensures that the system can handle diverse study types more effectively and promotes better maintenance and scalability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->