### PR TITLE
[#92][FEATURE] websocket 기반 STOMP 프로토콜 채팅 및 인증/인가 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.mapstruct:mapstruct:1.6.3'
-
-    implementation 'net.bytebuddy:byte-buddy'
 
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatController.java
@@ -1,0 +1,44 @@
+package com.studypals.domain.chatManage.api;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.chatManage.dto.IncomingMessage;
+import com.studypals.domain.chatManage.dto.OutgoingMessage;
+
+/**
+ * websocket 기반 stomp 채팅 시 message mapping 을 통해 바인딩되어 처리를 수행합니다.
+ * <pre>
+ *     - GET /send/message : 채팅 내용 전송 시 사용
+ * </pre>
+ *
+ * @author jack8
+ * @since 2025-06-19
+ */
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final SimpMessageSendingOperations template;
+
+    @MessageMapping("/send/message")
+    public void sendMessage(@Payload IncomingMessage message, Principal principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+        OutgoingMessage outgoingMessage = OutgoingMessage.builder()
+                .type(message.getType())
+                .message(message.getMessage())
+                .senderId(userId)
+                .time(LocalDateTime.now().toString())
+                .build();
+
+        template.convertAndSend("/sub/chat/room/" + message.getRoom(), outgoingMessage);
+    }
+}

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatController.java
@@ -1,17 +1,15 @@
 package com.studypals.domain.chatManage.api;
 
 import java.security.Principal;
-import java.time.LocalDateTime;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.chatManage.dto.IncomingMessage;
-import com.studypals.domain.chatManage.dto.OutgoingMessage;
+import com.studypals.domain.chatManage.service.ChatService;
 
 /**
  * websocket 기반 stomp 채팅 시 message mapping 을 통해 바인딩되어 처리를 수행합니다.
@@ -26,19 +24,16 @@ import com.studypals.domain.chatManage.dto.OutgoingMessage;
 @RequiredArgsConstructor
 public class ChatController {
 
-    private final SimpMessageSendingOperations template;
+    private final ChatService chatService;
 
     @MessageMapping("/send/message")
     public void sendMessage(@Payload IncomingMessage message, Principal principal) {
-
         Long userId = Long.parseLong(principal.getName());
-        OutgoingMessage outgoingMessage = OutgoingMessage.builder()
-                .type(message.getType())
-                .message(message.getMessage())
-                .senderId(userId)
-                .time(LocalDateTime.now().toString())
-                .build();
+        chatService.sendMessage(userId, message);
+    }
 
-        template.convertAndSend("/sub/chat/room/" + message.getRoom(), outgoingMessage);
+    @MessageMapping("/read/message")
+    public void readMessage(@Payload IncomingMessage message, Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
     }
 }

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepository.java
@@ -40,4 +40,6 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
     List<ChatRoomMember> findAllByMemberId(Long memberId);
 
     Optional<ChatRoomMember> findByChatRoomIdAndMemberId(String chatRoomId, Long memberId);
+
+    Boolean existsByChatRoomIdAndMemberId(String chatRoomId, Long memberId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatType.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatType.java
@@ -1,0 +1,17 @@
+package com.studypals.domain.chatManage.dto;
+
+/**
+ * 채팅 메시지의 type 을 정의합니다.
+ * 각 채팅 메시지 별 역할에 따라 구분됩니다.
+ *
+ * @author jack8
+ * @see IncomingMessage
+ * @see OutgoingMessage
+ * @since 2025-06-19
+ */
+public enum ChatType {
+    TEXT,
+    IMAGE,
+    READ,
+    STAT
+}

--- a/src/main/java/com/studypals/domain/chatManage/dto/IncomingMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/IncomingMessage.java
@@ -1,0 +1,21 @@
+package com.studypals.domain.chatManage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * client -> server 로의 메시지 형식을 정의합니다.
+ * 사용자로부터 최소한의 정보를 입력받아 메시지를 보냅니다.
+ *
+ * @author jack8
+ * @since 2025-06-19
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class IncomingMessage {
+    private ChatType type;
+    private String message;
+    private String room;
+}

--- a/src/main/java/com/studypals/domain/chatManage/dto/OutgoingMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/OutgoingMessage.java
@@ -1,0 +1,25 @@
+package com.studypals.domain.chatManage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * server -> client 로의 메시지 형식을 정의합니다.
+ * incomingMessage 에 대해, 일부 정보를 서버에서 추가하여 반환합니다.
+ *
+ * @author jack8
+ * @see IncomingMessage
+ * @since 2025-06-19
+ */
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OutgoingMessage {
+    private ChatType type;
+    private String message;
+    private Long senderId;
+    private String time;
+}

--- a/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatMessageMapper.java
@@ -1,0 +1,22 @@
+package com.studypals.domain.chatManage.dto.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.studypals.domain.chatManage.dto.IncomingMessage;
+import com.studypals.domain.chatManage.dto.OutgoingMessage;
+
+/**
+ * ChatMessage 에 대한 mapper 클래스입니다.
+ *
+ * @author jack8
+ * @since 2025-06-20
+ */
+@Mapper(componentModel = "spring")
+public interface ChatMessageMapper {
+
+    @Mapping(target = "room", ignore = true)
+    @Mapping(target = "senderId", source = "senderId")
+    @Mapping(target = "time", source = "time")
+    OutgoingMessage toOutMessage(IncomingMessage message, Long senderId, String time);
+}

--- a/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatMessageMapper.java
@@ -15,7 +15,6 @@ import com.studypals.domain.chatManage.dto.OutgoingMessage;
 @Mapper(componentModel = "spring")
 public interface ChatMessageMapper {
 
-    @Mapping(target = "room", ignore = true)
     @Mapping(target = "senderId", source = "senderId")
     @Mapping(target = "time", source = "time")
     OutgoingMessage toOutMessage(IncomingMessage message, Long senderId, String time);

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatService.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatService.java
@@ -1,0 +1,34 @@
+package com.studypals.domain.chatManage.service;
+
+import com.studypals.domain.chatManage.dto.IncomingMessage;
+
+/**
+ * websocket 기반의 메시지에 대하여 채팅을 저장/브로드 캐스트 등의 기능을 수행합니다.
+ * <p>
+ * 채팅의 전처리 후 브로드캐스트, 내역 저장, 읽음 커서 업데이트 등의 채팅과 관련된 작업을 수행합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * ChatServiceImpl 의 부모 인터페이스입니다.
+ *
+ * @author jack8
+ * @see ChatServiceImpl
+ * @since 2025-06-20
+ */
+public interface ChatService {
+
+    /**
+     * 채팅을 해당 방의 구독자에게 브로드캐스트합니다.
+     * 송신자의 id 와 시간 등을 추가하여, 전체 사용자에게 전파합니다.
+     * @param userId 송신자 id
+     * @param message 메시지 본문(송신자가 보낸 메시지)
+     */
+    void sendMessage(Long userId, IncomingMessage message);
+
+    /**
+     * 메시지를 읽고, 읽음 메시지를 처리합니다. 기본적으로 ScheduledExecutorService 를 이용해 묶어서 처리합니다.
+     * 비동기 - 버퍼링 방식을 통해 처리합니다. 다만, 배치 처리를 고민하고 있습니다.
+     * @param userId 송신자의 id
+     * @param message 읽음 메시지, message 에는 자신이 마지막으로 읽은 메시지의 id
+     */
+    void readMessage(Long userId, IncomingMessage message);
+}

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatServiceImpl.java
@@ -1,0 +1,46 @@
+package com.studypals.domain.chatManage.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.chatManage.dto.IncomingMessage;
+import com.studypals.domain.chatManage.dto.OutgoingMessage;
+import com.studypals.domain.chatManage.dto.mapper.ChatMessageMapper;
+
+/**
+ * <p><b>상속 정보:</b><br>
+ * {@link ChatService} 의 구현 클래스입니다.
+ *
+ * <p><b>빈 관리:</b><br>
+ * Service
+ *
+ * @author jack8
+ * @see ChatRoomService
+ * @since 2025-06-20
+ */
+@Service
+@RequiredArgsConstructor
+public class ChatServiceImpl implements ChatService {
+
+    private final SimpMessageSendingOperations template;
+    private final ChatMessageMapper chatMessageMapper;
+
+    private static final String DESTINATION_PREFIX = "/sub/chat/room/";
+
+    @Override
+    public void sendMessage(Long userId, IncomingMessage message) {
+        LocalDateTime now = LocalDateTime.now();
+        OutgoingMessage outgoingMessage = chatMessageMapper.toOutMessage(message, userId, now.toString());
+
+        template.convertAndSend(DESTINATION_PREFIX + message.getRoom(), outgoingMessage);
+    }
+
+    @Override
+    public void readMessage(Long userId, IncomingMessage message) {
+        // can't implement now //
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/errorCode/ChatErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/ChatErrorCode.java
@@ -32,7 +32,8 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_PERMISSION_DENIED(
             ResponseCode.CHAT_ROOM_SEARCH, HttpStatus.FORBIDDEN, "you have no permission to access this behavior"),
 
-    CHAT_SEND_FAIL(ResponseCode.CHAT_SEND, HttpStatus.INTERNAL_SERVER_ERROR, "send fail by internal error");
+    CHAT_SEND_FAIL(ResponseCode.CHAT_SEND, HttpStatus.INTERNAL_SERVER_ERROR, "send fail by internal error"),
+    CHAT_SUBSCRIBE_FAIL(ResponseCode.CHAT_SUBSCRIBE, HttpStatus.BAD_REQUEST, "subscribe fail");
 
     private final ResponseCode responseCode;
     private final HttpStatus status;

--- a/src/main/java/com/studypals/global/exceptions/errorCode/ChatErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/ChatErrorCode.java
@@ -30,7 +30,9 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_JOIN_FAIL(ResponseCode.CHAT_ROOM_JOIN, HttpStatus.INTERNAL_SERVER_ERROR, "can't join to chatroom"),
     CHAT_ROOM_ADMIN_LEAVE(ResponseCode.CHAT_ROOM_LEAVE, HttpStatus.BAD_REQUEST, "admin can't leave chatRoom"),
     CHAT_ROOM_PERMISSION_DENIED(
-            ResponseCode.CHAT_ROOM_SEARCH, HttpStatus.FORBIDDEN, "you have no permission to access this behavior");
+            ResponseCode.CHAT_ROOM_SEARCH, HttpStatus.FORBIDDEN, "you have no permission to access this behavior"),
+
+    CHAT_SEND_FAIL(ResponseCode.CHAT_SEND, HttpStatus.INTERNAL_SERVER_ERROR, "send fail by internal error");
 
     private final ResponseCode responseCode;
     private final HttpStatus status;

--- a/src/main/java/com/studypals/global/responses/ResponseCode.java
+++ b/src/main/java/com/studypals/global/responses/ResponseCode.java
@@ -62,7 +62,10 @@ public enum ResponseCode {
     CHAT_ROOM_UPDATE("C01-03"),
     CHAT_ROOM_JOIN("C01-04"),
     CHAT_ROOM_LEAVE("C01-05"),
-    CHAT_ROOM_ROLE("C01-06");
+    CHAT_ROOM_ROLE("C01-06"),
+
+    CHAT_SEND("C02-00"),
+    CHAT_SUBSCRIBE("C02-01");
 
     private final String code;
 

--- a/src/main/java/com/studypals/global/security/config/AccessURL.java
+++ b/src/main/java/com/studypals/global/security/config/AccessURL.java
@@ -14,7 +14,7 @@ import lombok.Getter;
  */
 @Getter
 public enum AccessURL {
-    PUBLIC(List.of("/sign-in", "/register", "/first-page", "/refresh", "/docs/**"));
+    PUBLIC(List.of("/sign-in", "/register", "/first-page", "/refresh", "/docs/**", "/ws/**"));
 
     private final List<String> urls;
 

--- a/src/main/java/com/studypals/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/studypals/global/websocket/StompAuthChannelInterceptor.java
@@ -1,0 +1,140 @@
+package com.studypals.global.websocket;
+
+import java.security.Principal;
+
+import org.springframework.core.env.PropertyResolver;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.chatManage.dao.ChatRoomMemberRepository;
+import com.studypals.global.exceptions.errorCode.AuthErrorCode;
+import com.studypals.global.exceptions.errorCode.ChatErrorCode;
+import com.studypals.global.exceptions.exception.AuthException;
+import com.studypals.global.exceptions.exception.BaseException;
+import com.studypals.global.exceptions.exception.ChatException;
+import com.studypals.global.security.jwt.JwtToken;
+import com.studypals.global.security.jwt.JwtUtils;
+
+/**
+ * websocket 기반의 통신에서, STOMP 프로토콜 위에서 작동한다 할 때, controller 로 바인딩 되기 전
+ * 메시지를 가로채, 인증 과정을 진행합니다.
+ * <p>
+ * {@link ChannelInterceptor} 를 구현하여 {@code preSend} 및 {@code afterSendCompletion} 메서드를 구현하여,
+ * 세션 아이디와 유저 정보 및 인증/인가 처리를 수행합니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * {@link ChannelInterceptor} 를 상속
+ *
+ * @author jack8
+ * @since 2025-06-19
+ */
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtUtils jwtUtils;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+
+    private static final String ACCESS_HEADER = "Authorization";
+    private final PropertyResolver propertyResolver;
+
+    /**
+     * 메시지가 controller 로 바인딩 되기 전 과정을 수행합니다. 보통 {@code CONNECT, SUBSCRIBE, SEND} 에 대한
+     * intercept 가 가능합니다.
+     *
+     * Principal 을 사용하여 각 세션에 따른 사용자 정보를 저장하고, controller 에서 이를 받을 수 있도록 합니다.
+     *
+     * @param message 실제로 받는 메시지
+     * @param channel (사용하지 않음)
+     * @return 받은 메시지(SEND 시 일부 후처리)
+     */
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) throw new IllegalArgumentException("not invalid protocol");
+        if (accessor.getCommand() == null) throw new IllegalArgumentException("header not exist");
+
+        try {
+            switch (accessor.getCommand()) {
+                case CONNECT -> handleConnect(accessor);
+                case SUBSCRIBE -> handleSubscribe(accessor);
+            }
+        } catch (BaseException e) {
+            return null;
+        }
+
+        return message;
+    }
+
+    private void handleConnect(StompHeaderAccessor accessor) {
+        // connect 시 header 로부터 토큰 추출
+        String token = accessor.getFirstNativeHeader(ACCESS_HEADER);
+
+        // 토큰 검증
+        if (StringUtils.hasText(token) && token.startsWith(JwtToken.BEARER_PREFIX)) {
+            token = token.substring(JwtToken.BEARER_PREFIX_LENGTH);
+        } else {
+            throw new AuthException(
+                    AuthErrorCode.USER_AUTH_FAIL, "[StompAuthChannelInterceptor#handleConnect] unknown token type");
+        }
+
+        JwtUtils.JwtData jwtData = jwtUtils.tokenInfo(token);
+        if (jwtData.isInvalid()) {
+            throw new AuthException(
+                    AuthErrorCode.USER_AUTH_FAIL, "[StompAuthChannelInterceptor#handleConnect] invalid token");
+        }
+
+        // 토큰으로부터 userId 추출
+        Long userId = jwtData.getId();
+
+        // 해당 정보를 저장 - sessionId에 따른 userId
+
+        StompPrincipal principal = new StompPrincipal(userId);
+        accessor.setUser(principal);
+    }
+
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+
+        // url 을 추출
+        String destination = accessor.getDestination();
+        if (destination == null)
+            throw new ChatException(
+                    ChatErrorCode.CHAT_SUBSCRIBE_FAIL,
+                    "[StompAuthChannelInterceptor#handleSubscribe] destination null");
+
+        // url 로 부터 구독하고자 하는 방의 id 를 추출
+        String roomId = extractRoomIdFromDestination(destination);
+
+        Principal principal = accessor.getUser();
+        if (!(principal instanceof StompPrincipal stompPrincipal)) {
+            throw new ChatException(
+                    ChatErrorCode.CHAT_SUBSCRIBE_FAIL, "[StompAuthChannelInterceptor#handleSubscribe] principal null");
+        }
+        Long userId = Long.parseLong(stompPrincipal.getName());
+
+        // 해당 유저가 해당 채팅방에 소속되어 있는지 확인
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndMemberId(roomId, userId)) {
+            throw new ChatException(
+                    ChatErrorCode.CHAT_SUBSCRIBE_FAIL,
+                    "[StompAuthChannelInterceptor#handleSubscribe] user not in this room");
+        }
+    }
+
+    private String extractRoomIdFromDestination(String destination) {
+        // 예: "/sub/chat/room/{roomId}" 형식에서 {roomId}만 추출
+        if (destination != null && destination.contains("/chat/room/")) {
+            return destination.substring(destination.lastIndexOf("/") + 1);
+        }
+        throw new ChatException(
+                ChatErrorCode.CHAT_SUBSCRIBE_FAIL,
+                "[StompAuthChannelInterceptor#handleSubscribe] destination format invalid");
+    }
+}

--- a/src/main/java/com/studypals/global/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/studypals/global/websocket/StompAuthChannelInterceptor.java
@@ -2,7 +2,6 @@ package com.studypals.global.websocket;
 
 import java.security.Principal;
 
-import org.springframework.core.env.PropertyResolver;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -43,7 +42,6 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
 
     private static final String ACCESS_HEADER = "Authorization";
-    private final PropertyResolver propertyResolver;
 
     /**
      * 메시지가 controller 로 바인딩 되기 전 과정을 수행합니다. 보통 {@code CONNECT, SUBSCRIBE, SEND} 에 대한

--- a/src/main/java/com/studypals/global/websocket/StompPrincipal.java
+++ b/src/main/java/com/studypals/global/websocket/StompPrincipal.java
@@ -1,0 +1,38 @@
+package com.studypals.global.websocket;
+
+import java.security.Principal;
+
+/**
+ * 코드에 대한 전체적인 역할을 적습니다.
+ * <p>
+ * 코드에 대한 작동 원리 등을 적습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 상속 정보를 적습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code ExampleClass(String example)}  <br>
+ * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
+ *
+ * <p><b>빈 관리:</b><br>
+ * 필요 시 빈 관리에 대한 내용을 적습니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ *
+ * @author jack8
+ * @see
+ * @since 2025-06-19
+ */
+public class StompPrincipal implements Principal {
+    private final String name;
+
+    public StompPrincipal(Long userId) {
+        this.name = userId.toString();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/studypals/global/websocket/StompPrincipal.java
+++ b/src/main/java/com/studypals/global/websocket/StompPrincipal.java
@@ -3,25 +3,12 @@ package com.studypals.global.websocket;
 import java.security.Principal;
 
 /**
- * 코드에 대한 전체적인 역할을 적습니다.
- * <p>
- * 코드에 대한 작동 원리 등을 적습니다.
+ * websocket 연결에 대한 정보를 저장하기 위한 객체입니다. Principal 의 구현체로서,
+ * websocket interceptor 에서 세션에 대해 user로서 설정할 수 있습니다.
  *
- * <p><b>상속 정보:</b><br>
- * 상속 정보를 적습니다.
- *
- * <p><b>주요 생성자:</b><br>
- * {@code ExampleClass(String example)}  <br>
- * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
- *
- * <p><b>빈 관리:</b><br>
- * 필요 시 빈 관리에 대한 내용을 적습니다.
- *
- * <p><b>외부 모듈:</b><br>
- * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ * 반환 타입이 String 이라 name 을 String 으로 잡기는 하였으나 userId가 들어갑니다.
  *
  * @author jack8
- * @see
  * @since 2025-06-19
  */
 public class StompPrincipal implements Principal {

--- a/src/main/java/com/studypals/global/websocket/WebsocketConfig.java
+++ b/src/main/java/com/studypals/global/websocket/WebsocketConfig.java
@@ -1,0 +1,56 @@
+package com.studypals.global.websocket;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 코드에 대한 전체적인 역할을 적습니다.
+ * <p>
+ * 코드에 대한 작동 원리 등을 적습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 상속 정보를 적습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code ExampleClass(String example)}  <br>
+ * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
+ *
+ * <p><b>빈 관리:</b><br>
+ * 필요 시 빈 관리에 대한 내용을 적습니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ *
+ * @author jack8
+ * @see
+ * @since 2025-06-19
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/sub");
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    }
+}

--- a/src/main/java/com/studypals/global/websocket/WebsocketConfig.java
+++ b/src/main/java/com/studypals/global/websocket/WebsocketConfig.java
@@ -10,25 +10,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 import lombok.RequiredArgsConstructor;
 
 /**
- * 코드에 대한 전체적인 역할을 적습니다.
- * <p>
- * 코드에 대한 작동 원리 등을 적습니다.
- *
- * <p><b>상속 정보:</b><br>
- * 상속 정보를 적습니다.
- *
- * <p><b>주요 생성자:</b><br>
- * {@code ExampleClass(String example)}  <br>
- * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
+ * websocket 연결에 대한 설정 클래스입니다.
+ * 연결 엔드포인트, 인터셉터, 브로커 등을 설정합니다.
  *
  * <p><b>빈 관리:</b><br>
- * 필요 시 빈 관리에 대한 내용을 적습니다.
- *
- * <p><b>외부 모듈:</b><br>
- * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ * Configuration
  *
  * @author jack8
- * @see
  * @since 2025-06-19
  */
 @Configuration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.datasource.password=${MYSQL_PWD}
 #mysql settings
 
 spring.jpa.show-sql=false
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
 
 spring.data.redis.host=${REDIS_HOST}

--- a/src/test/java/com/studypals/domain/chatManage/service/ChatServiceTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/service/ChatServiceTest.java
@@ -1,0 +1,55 @@
+package com.studypals.domain.chatManage.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+
+import com.studypals.domain.chatManage.dto.ChatType;
+import com.studypals.domain.chatManage.dto.IncomingMessage;
+import com.studypals.domain.chatManage.dto.OutgoingMessage;
+import com.studypals.domain.chatManage.dto.mapper.ChatMessageMapper;
+
+/**
+ * {@link ChatService} 에 대한 테스트코드입니다.
+ *
+ * @author jack8
+ * @since 2025-06-20
+ */
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    @Mock
+    private SimpMessageSendingOperations template;
+
+    @Mock
+    private ChatMessageMapper chatMessageMapper;
+
+    @InjectMocks
+    private ChatServiceImpl chatService;
+
+    private IncomingMessage createIncoming() {
+        return new IncomingMessage(ChatType.TEXT, "test message", "room-id");
+    }
+
+    private OutgoingMessage createOutgoing(Long userId, String time) {
+        return new OutgoingMessage(ChatType.TEXT, "text message", userId, time);
+    }
+
+    @Test
+    void sendMessage_success() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        OutgoingMessage outgoingMessage = createOutgoing(1L, now.toString());
+        given(chatMessageMapper.toOutMessage(any(), any(), any())).willReturn(outgoingMessage);
+        willDoNothing().given(template).convertAndSend(any(String.class), any(Object.class));
+    }
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #92

## ✨ 구현 기능 명세

websocket 기반의 stomp 프로토콜 채팅입니다.
interceptor 를 통해 connect 과정에서 jwt 인증을 수행하여, 해당 세션에 custom Principal 을 적용하여 유저 정보를 저장하고, subscribe 시 해당 유저가 해당 채팅방을 구독할 권한이 존재하는지 검사합니다.

채팅 과정에서 발생하는 예외 등도 정의는 해 놓았으나 intercept 과정에서 발생하는 예외의 경우 일단은 null을 반환토록 처리하였습니다. 해당 과정은 추후 상의 후 결정해야 된다고 판단했기 때문입니다. 

내용 자체가 그리 많지는 않습니다. 
추후 확장 포인트를 다음과 같이 잡았습니다.

- 채팅 메시지에 id 를 부여하여 로그 저장 및 추후 읽음 카운트를 위해 유저별로 읽음 커서를 저장/관리
- 메시지 브로커를 외부 메시지 브로커로 이전
- 읽음 카운트에 대해 현재 접속해 있는 유저 카운트에 따라 처리 로직이 달라지게 수행. 유저 수가 20명 이하면(현재 접속 중인) 버퍼링 방식이 아닌 바로 처리되게끔
- SSE 를 이용해 채팅 방 정보 반환하도록(추후 논의 필요)

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

단순 기능적 구현이고, 실제 채팅을 받아 처리하는 api 및 service 쪽은 앞서 이야기 한 대로 추후 확장 후 마저 구현할 예정입니다. 이는 단순히 테스트를 위해서 아주 간단한 형태로만 구현한 것이라 해당 부분은 크게 신경쓰지 않으셔도 될 것 같습니다.

interceptor 의 경우, 사실 event handler 로 처리할까도 고민하긴 했습니다. 오버헤드적 측면에서 후자의 방식이 더 좋긴 합니다. 다만, 보안적인 측면에서 interceptor가 더 좋다는 생각이었습니다.

엔드 포인트는 아주 기본적인 형태 즉 /sub , /pub 를 사용했는데, 추가적인 의견 있으면 제시 부탁드립니다. 가령 "."을 사용한다 던지요.

클라이언트는 서버로 채팅방 id 와 메시지를 보내면 서버는 여기에 시간, sender id (추후 메시지 아이디도)를 덧붙여 브로드캐스트 할 예정입니다. 음, send 시 여기서 받은 채팅방 아이디에 그대로 브로드캐스트 하긴 합니다. 따라서, 작정하고 마음 먹으면, 특정 채팅방으로부터 브로드캐스트 되는 메시지는 받지 못해도, 메시지를 보낼 수는 있는 보안적 이슈가 있습니다.

이를 꼭 해결해야 할까에 대한 의문이 들긴 합니다. 이를 보완하고자 한다면, 

메모리에 세션-userid-구독한 roomid 를 저장하고, 사용자가 메시지를 보내면 
1. 해당 메시지를 사용자가 구독한 roomId를 찾아서(subscribe 시 저장했던) 보낸다.
2. 사용자가 입력한 roomId 를 매번 전송 때마다 검증한다.

전자의 경우, 한 유저가 동시에 하나의 토픽만 구독할 수 있다는 단점이 존재하고,
두번째의 경우 오버헤드가 좀 클 것 같네요.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
