### PR TITLE
build: dockerfile 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 # Copy the build files
-COPY build/libs/studyPals-dev-0.0.1-SNAPSHOT.jar ./app.jar
+COPY build/libs/studyPals-0.0.1-SNAPSHOT.jar ./app.jar
 
 # Expose the port the application runs on
 EXPOSE 8080

--- a/DockerfileDev
+++ b/DockerfileDev
@@ -5,7 +5,7 @@ FROM openjdk:17-jdk-slim
 WORKDIR /app
 
 # Copy the build files
-COPY build/libs/studyPals-0.0.1-SNAPSHOT.jar ./app.jar
+COPY build/libs/studyPals-dev-0.0.1-SNAPSHOT.jar ./app.jar
 
 # Expose the port the application runs on
 EXPOSE 7070


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update Docker build files to package the correct artifacts:
- Dockerfile now copies studyPals-0.0.1-SNAPSHOT.jar as app.jar
- DockerfileDev now copies studyPals-dev-0.0.1-SNAPSHOT.jar as app.jar

### Why are these changes being made?

Fix artifact name mismatch so the Docker images contain the intended JARs (prod and dev variants) and expose the correct ports (8080 for prod, 7070 for dev).

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->