### PR TITLE
[#69][FEATURE[ SSE를 이용한 채팅방 기록 불러오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.12.6"
 
     // redis
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.session:spring-session-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/src/asciidoc/api/chat.adoc
+++ b/src/asciidoc/api/chat.adoc
@@ -65,12 +65,13 @@ include::{snippets}/chat-room-controller-rest-docs-test/get-chat-room-info_succe
 include::{snippets}/chat-room-controller-rest-docs-test/get-chat-room-info_success/response-fields.adoc[]
 include::{snippets}/chat-room-controller-rest-docs-test/get-chat-room-info_success/http-response.adoc[]
 
-''''
+'''
+'''
 
 === 채팅
-''''
 
-==== CONNECT frame
+'''
+==== - CONNECT frame
 
 클라이언트 -> 서버
 [source,stomp]
@@ -83,9 +84,10 @@ Authorization:Bearer {ACCESS_TOKEN}
 ^@
 ----
 [NOTE]
-`{ACCESS_TOEKN}` 은 로그인부터 발급받은 토큰을 사용합니다.
+`{ACCESS_TOKEN}` 은 로그인부터 발급받은 토큰을 사용합니다.
 
-==== SUBSCRIBE frame (채팅방 구독)
+'''
+==== - SUBSCRIBE frame (채팅방 구독)
 
 클라이언트 → 서버
 
@@ -101,8 +103,8 @@ destination:/sub/chat/room/{chatRoomId}
 서버는 이후 `/sub/chat/room/{chatRoomId}` 로 전달되는 MESSAGE 프레임을
 해당 세션으로 push 해야합니다.
 
-
-==== SEND frame (채팅 메시지 전송)
+'''
+==== - SEND frame (채팅 메시지 전송)
 
 [WARNING]
 클라이언트에서는 메시지를 보낼 때, 다음과 같은 방식으로 보내야 합니다. 단, SEND 시 사용되는 chatRoomId 는,
@@ -145,8 +147,9 @@ message-id:msg-15
 ^@
 ----
 
+'''
 
-==== SEND frame (읽음 처리)
+==== - SEND frame (읽음 처리)
 
 클라이언트는 메시지를 읽으면, 가장 마지막으로 읽은 메시지를 서버로 보내야 합니다.
 이는 필수적인 과정이며 클라이언트 측에서 어느정도 최적화를 하면 서버 측의 부담이 줄어들 여지가 있습니다.
@@ -172,8 +175,8 @@ content-type:application/json
 }
 ^@
 ----
-
-==== SUBSCRIBE frame (유저 개인 큐 구독)
+'''
+==== - SUBSCRIBE frame (유저 개인 큐 구독)
 
 /user/queue 는 특정 유저에게만 전달되는 개인용 메시지를 받기 위한 채널입니다.
 클라이언트는 다음과 같이 단순히 구독만 하면 됩니다.
@@ -195,8 +198,8 @@ destination:/user/queue/notifications
 
 이후 해당 유저에게 전달되는 개인 메시지가 모두 이 채널로 도착합니다.
 
-
-==== USER QUEUE MESSAGE frame (개인 메시지)
+'''
+==== - USER QUEUE MESSAGE frame (개인 메시지)
 
 서버 → 클라이언트
 
@@ -215,3 +218,152 @@ message-id:user-msg-1
 ----
 [NOTE]
 단, 개인 메시지의 형식은 아직 정의되지 않았습니다.
+
+'''
+'''
+
+=== 채팅방 리스트(SSE)
+`/sse/chat/room/list`
+
+클라이언트는 SSE 를 통해 유저가 속한 채팅방 리스트를 받아올 수 있습니다. 현재까지 구현된 바에 따르면, 데이터는 총 2가지 타입이 존재합니다.
+
+최초 연결 후 보내지는 메시지는 연결 시점의 채팅방 리스트 및 각 채팅방의 데이터가 포함됩니다.
+
+- 채팅방 아이디
+- 채팅방 이름
+- 채팅방 이미지 URL
+- 참여자 수
+- 안 읽은 메시지 카운트
+- 가장 마지막 메시지
+- 가장 마지막 메시지 아이디
+- 가장 마지막 메시지 sender id
+
+이후 보내지는 메시지는 초기 메시지 이후 발행되는 새로운 메시지에 대한 정보입니다. 각 사용자가 메시지를 보내게 되면 접속 중인 SSE 세션으로
+해당 메시지 정보가 전송됩니다. 이때의 데이터는 채팅방에서 받는 새로운 채팅 데이터와 동일합니다.
+
+- 채팅방 아이디
+- 채팅 아이디
+- 채팅 내용
+- 채팅 타입
+- sender id
+
+[NOTE]
+모든 SSE 메시지는 type - body 로 구성됩니다. type 은 해당 메시지의 종류, body 는 실제 데이터입니다.
+
+[NOTE]
+SSE 연결 후, 채팅방 리스트를 받기 전 `connect` type 의 메시지가 먼저 보내집니다. 이는 채팅방 리스트 API 뿐 만 아니라, SSE 연결
+모두에 적용됩니다. body 는 없습니다. `(empty)`
+
+'''
+
+==== - [init-message]
+다음은 SSE 초기 메시지(`init-message`)로 전달되는 채팅방 목록 응답의 필드 설명이다.
+
+
+|===
+| Path | Type | Description
+
+| rooms | Array | 사용자가 가입한 채팅방 목록
+
+| rooms[].chatRoomId
+| String
+| 채팅방 ID (UUID)
+
+| rooms[].chatRoomName
+| String
+| 채팅방 이름
+
+| rooms[].chatRoomUrl
+| String or null
+| 채팅방 대표 이미지 URL. 없으면 null
+
+| rooms[].totalMember
+| Number
+| 현재 채팅방 총 멤버 수
+
+| rooms[].unread
+| Number
+| 사용자가 읽지 않은 메시지 수
+`-1`이면 최근 메시지 없음 (아직 채팅방에 채팅이 존재하지 않음)
+
+| rooms[].lastMessage
+| String or null
+| 마지막 메시지 내용. 메시지가 없으면 null
+
+| rooms[].messageId
+| String or null
+| 마지막 메시지 ID. 메시지가 없으면 null
+
+| rooms[].sender
+| Number or null
+| 마지막 메시지를 보낸 사용자 ID. 없으면 null
+|===
+
+[source,json]
+----
+{
+    "rooms": [
+        {
+            "chatRoomId": "3ff392ab-a606-468b-8330-60f3c0d6edf3",
+            "chatRoomName": "group1",
+            "chatRoomUrl": null,
+            "totalMember": 1,
+            "unread": 1,
+            "lastMessage": "hello world",
+            "messageId": "1418e71356571000",
+            "sender": 1
+        },
+        {
+            "chatRoomId": "9c5ff7dc-5cbe-4b58-b6cf-89ff79d895a9",
+            "chatRoomName": "group",
+            "chatRoomUrl": null,
+            "totalMember": 1,
+            "unread": -1,
+            "lastMessage": null,
+            "messageId": null,
+            "sender": null
+        }
+    ]
+}
+----
+
+'''
+==== - [new-message]
+다음은 SSE 실시간 메시지(new-message)로 전달되는 새로운 채팅 데이터에 대한 필드 설명이다.
+
+|===
+| Path | Type | Description
+
+| id
+| String
+| 메시지 ID. 64비트 기반 커스텀 ID (정렬·정합성 확보용)
+
+| room
+| String
+| 메시지가 속한 채팅방 ID (UUID)
+
+| type
+| String
+| 메시지 타입
+예: `TEXT`, `IMAGE`, `JOIN`, `LEAVE` 등
+
+| message
+| String
+| 메시지 본문. 텍스트 메시지가 아닌 경우 다른 필드와 조합해 사용될 수 있음
+
+| sender
+| Number
+| 메시지를 보낸 사용자 ID
+|===
+
+
+[source,json]
+----
+{
+    "id": "1418e7ad87971000",
+    "room": "3ff392ab-a606-468b-8330-60f3c0d6edf3",
+    "type": "TEXT",
+    "message": "hello world",
+    "sender": 1
+}
+----

--- a/src/asciidoc/api/chat.adoc
+++ b/src/asciidoc/api/chat.adoc
@@ -265,15 +265,15 @@ SSE 연결 후, 채팅방 리스트를 받기 전 `connect` type 의 메시지�
 
 | rooms | Array | 사용자가 가입한 채팅방 목록
 
-| rooms[].chatRoomId
+| rooms[].roomId
 | String
 | 채팅방 ID (UUID)
 
-| rooms[].chatRoomName
+| rooms[].name
 | String
 | 채팅방 이름
 
-| rooms[].chatRoomUrl
+| rooms[].url
 | String or null
 | 채팅방 대표 이미지 URL. 없으면 null
 
@@ -286,11 +286,11 @@ SSE 연결 후, 채팅방 리스트를 받기 전 `connect` type 의 메시지�
 | 사용자가 읽지 않은 메시지 수
 `-1`이면 최근 메시지 없음 (아직 채팅방에 채팅이 존재하지 않음)
 
-| rooms[].lastMessage
+| rooms[].content
 | String or null
 | 마지막 메시지 내용. 메시지가 없으면 null
 
-| rooms[].messageId
+| rooms[].chatId
 | String or null
 | 마지막 메시지 ID. 메시지가 없으면 null
 
@@ -304,23 +304,23 @@ SSE 연결 후, 채팅방 리스트를 받기 전 `connect` type 의 메시지�
 {
     "rooms": [
         {
-            "chatRoomId": "3ff392ab-a606-468b-8330-60f3c0d6edf3",
-            "chatRoomName": "group1",
-            "chatRoomUrl": null,
+            "roomId": "3ff392ab-a606-468b-8330-60f3c0d6edf3",
+            "name": "group1",
+            "url": null,
             "totalMember": 1,
             "unread": 1,
-            "lastMessage": "hello world",
-            "messageId": "1418e71356571000",
+            "content": "hello world",
+            "chatId": "1418e71356571000",
             "sender": 1
         },
         {
-            "chatRoomId": "9c5ff7dc-5cbe-4b58-b6cf-89ff79d895a9",
-            "chatRoomName": "group",
-            "chatRoomUrl": null,
+            "roomId": "9c5ff7dc-5cbe-4b58-b6cf-89ff79d895a9",
+            "name": "group",
+            "url": null,
             "totalMember": 1,
             "unread": -1,
-            "lastMessage": null,
-            "messageId": null,
+            "content": null,
+            "chatId": null,
             "sender": null
         }
     ]
@@ -338,7 +338,7 @@ SSE 연결 후, 채팅방 리스트를 받기 전 `connect` type 의 메시지�
 | String
 | 메시지 ID. 64비트 기반 커스텀 ID (정렬·정합성 확보용)
 
-| room
+| roomId
 | String
 | 메시지가 속한 채팅방 ID (UUID)
 
@@ -361,7 +361,7 @@ SSE 연결 후, 채팅방 리스트를 받기 전 `connect` type 의 메시지�
 ----
 {
     "id": "1418e7ad87971000",
-    "room": "3ff392ab-a606-468b-8330-60f3c0d6edf3",
+    "roomId": "3ff392ab-a606-468b-8330-60f3c0d6edf3",
     "type": "TEXT",
     "message": "hello world",
     "sender": 1

--- a/src/asciidoc/api/study.adoc
+++ b/src/asciidoc/api/study.adoc
@@ -237,15 +237,15 @@ include::{snippets}/study-session-controller-rest-docs-test/end_success/http-res
 *REQUEST* +
 
 '''
-include::{snippets}/study-time-controller-rest-docs-test/studies-date-by-period_success/query-parameters.adoc[]
-include::{snippets}/study-time-controller-rest-docs-test/studies-date-by-period_success/http-request.adoc[]
+include::{snippets}/study-time-controller-rest-docs-test/get-studies-info-by-date/query-parameters.adoc[]
+include::{snippets}/study-time-controller-rest-docs-test/get-studies-info-by-date/http-request.adoc[]
 
 *RESPONSE* +
 
 '''
 
-include::{snippets}/study-time-controller-rest-docs-test/studies-date-by-period_success/response-fields.adoc[]
-include::{snippets}/study-time-controller-rest-docs-test/studies-date-by-period_success/http-response.adoc[]
+include::{snippets}/study-time-controller-rest-docs-test/get-studies-info-by-date/response-fields.adoc[]
+include::{snippets}/study-time-controller-rest-docs-test/get-studies-info-by-date/http-response.adoc[]
 
 ==== 2. 특정 기간 간 공부 데이터 가져오기
 

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatController.java
@@ -37,7 +37,7 @@ public class ChatController {
         Long userId = Long.parseLong(principal.getName());
 
         // 유저가 송신하는 목적지가 가능한 값인지 검증(채팅방에 속해 있는지)
-        chatService.sendDestinationValidate(sessionId, message.getRoom());
+        chatService.sendDestinationValidate(sessionId, message.getRoomId());
         // 메시지를 전송
         chatService.sendMessage(userId, message);
     }

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
@@ -8,11 +8,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
+import com.studypals.domain.chatManage.dto.ChatRoomListRes;
 import com.studypals.domain.chatManage.service.ChatRoomService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
 import com.studypals.global.responses.ResponseCode;
 import com.studypals.global.sse.SseEmitterManager;
+import com.studypals.global.sse.SseSendDto;
 
 /**
  * 채팅방 전반에 걸친 정보를 받는 엔드포인트입니다. 채팅방 정보, 로그 조회, 참여한 사용자 조회 등,
@@ -20,6 +22,7 @@ import com.studypals.global.sse.SseEmitterManager;
  *
  * <pre>
  *     - GET /chat/room/{chatRoomId} : 채팅방 정보 조회
+ *     - GET /chat/room/list : SSE 기반, 채팅방 리스트 조회
  * </pre>
  *
  * @author jack8
@@ -44,9 +47,18 @@ public class ChatRoomController {
         return ResponseEntity.ok(CommonResponse.success(ResponseCode.CHAT_ROOM_SEARCH, chatRoomInfo, chatRoomId));
     }
 
+    /**
+     * SSE 기반의 채팅 리스트 반환 API 입니다. 사용자가 해당 uri 를 이용해 요청을 보내는 경우,
+     * {@link SseEmitterManager} 에서 관리하는 emitter 를 통해 메시지를 비동기적으로 보낼 수 있습니다. <br>
+     * 해당 메서드에서는 최초 1회에 대해 init-message 타입으로 초기 채팅방 데이터를 전송합니다.  <br>
+     * @param userId
+     * @return
+     */
     @GetMapping("/list")
     public SseEmitter getList(@AuthenticationPrincipal Long userId) {
         SseEmitter emitter = sseManager.createEmitter(userId);
+        ChatRoomListRes res = chatRoomService.getChatRoomList(userId);
+        sseManager.sendMessageAsync(userId, new SseSendDto("init-message", res));
 
         return emitter;
     }

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
@@ -51,8 +51,6 @@ public class ChatRoomController {
      * SSE 기반의 채팅 리스트 반환 API 입니다. 사용자가 해당 uri 를 이용해 요청을 보내는 경우,
      * {@link SseEmitterManager} 에서 관리하는 emitter 를 통해 메시지를 비동기적으로 보낼 수 있습니다. <br>
      * 해당 메서드에서는 최초 1회에 대해 init-message 타입으로 초기 채팅방 데이터를 전송합니다.  <br>
-     * @param userId
-     * @return
      */
     @GetMapping("/list")
     public SseEmitter getList(@AuthenticationPrincipal Long userId) {

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
@@ -3,18 +3,14 @@ package com.studypals.domain.chatManage.api;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
-import com.studypals.domain.chatManage.dto.ChatRoomListRes;
 import com.studypals.domain.chatManage.service.ChatRoomService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
 import com.studypals.global.responses.ResponseCode;
-import com.studypals.global.sse.SseEmitterManager;
-import com.studypals.global.sse.SseSendDto;
 
 /**
  * 채팅방 전반에 걸친 정보를 받는 엔드포인트입니다. 채팅방 정보, 로그 조회, 참여한 사용자 조회 등,
@@ -22,7 +18,6 @@ import com.studypals.global.sse.SseSendDto;
  *
  * <pre>
  *     - GET /chat/room/{chatRoomId} : 채팅방 정보 조회
- *     - GET /chat/room/list : SSE 기반, 채팅방 리스트 조회
  * </pre>
  *
  * @author jack8
@@ -34,7 +29,6 @@ import com.studypals.global.sse.SseSendDto;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
-    private final SseEmitterManager sseManager;
 
     // 구독 이후, 해당 요청 보냄 -> 응답을 받고 정렬 마칠 때 까지, 새로운 메시지가 와도 일단 렌더링 중지, 마치고 렌더링
     @GetMapping("/{chatRoomId}")
@@ -45,19 +39,5 @@ public class ChatRoomController {
         ChatRoomInfoRes chatRoomInfo = chatRoomService.getChatRoomInfo(userId, chatRoomId, chatId);
 
         return ResponseEntity.ok(CommonResponse.success(ResponseCode.CHAT_ROOM_SEARCH, chatRoomInfo, chatRoomId));
-    }
-
-    /**
-     * SSE 기반의 채팅 리스트 반환 API 입니다. 사용자가 해당 uri 를 이용해 요청을 보내는 경우,
-     * {@link SseEmitterManager} 에서 관리하는 emitter 를 통해 메시지를 비동기적으로 보낼 수 있습니다. <br>
-     * 해당 메서드에서는 최초 1회에 대해 init-message 타입으로 초기 채팅방 데이터를 전송합니다.  <br>
-     */
-    @GetMapping("/list")
-    public SseEmitter getList(@AuthenticationPrincipal Long userId) {
-        SseEmitter emitter = sseManager.createEmitter(userId);
-        ChatRoomListRes res = chatRoomService.getChatRoomList(userId);
-        sseManager.sendMessageAsync(userId, new SseSendDto("init-message", res));
-
-        return emitter;
     }
 }

--- a/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/ChatRoomController.java
@@ -3,6 +3,7 @@ package com.studypals.domain.chatManage.api;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +12,7 @@ import com.studypals.domain.chatManage.service.ChatRoomService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
 import com.studypals.global.responses.ResponseCode;
+import com.studypals.global.sse.SseEmitterManager;
 
 /**
  * 채팅방 전반에 걸친 정보를 받는 엔드포인트입니다. 채팅방 정보, 로그 조회, 참여한 사용자 조회 등,
@@ -29,6 +31,7 @@ import com.studypals.global.responses.ResponseCode;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+    private final SseEmitterManager sseManager;
 
     // 구독 이후, 해당 요청 보냄 -> 응답을 받고 정렬 마칠 때 까지, 새로운 메시지가 와도 일단 렌더링 중지, 마치고 렌더링
     @GetMapping("/{chatRoomId}")
@@ -39,5 +42,12 @@ public class ChatRoomController {
         ChatRoomInfoRes chatRoomInfo = chatRoomService.getChatRoomInfo(userId, chatRoomId, chatId);
 
         return ResponseEntity.ok(CommonResponse.success(ResponseCode.CHAT_ROOM_SEARCH, chatRoomInfo, chatRoomId));
+    }
+
+    @GetMapping("/list")
+    public SseEmitter getList(@AuthenticationPrincipal Long userId) {
+        SseEmitter emitter = sseManager.createEmitter(userId);
+
+        return emitter;
     }
 }

--- a/src/main/java/com/studypals/domain/chatManage/api/SseChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/SseChatRoomController.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.chatManage.dto.ChatRoomListRes;
+import com.studypals.domain.chatManage.entity.ChatSseType;
 import com.studypals.domain.chatManage.service.ChatRoomService;
 import com.studypals.global.sse.SseEmitterManager;
 import com.studypals.global.sse.SseSendDto;
@@ -35,7 +36,7 @@ public class SseChatRoomController {
     public SseEmitter getList(@AuthenticationPrincipal Long userId) {
         SseEmitter emitter = sseManager.createEmitter(userId);
         ChatRoomListRes res = chatRoomService.getChatRoomList(userId);
-        sseManager.sendMessageAsync(userId, new SseSendDto("init-message", res));
+        sseManager.sendMessageAsync(userId, new SseSendDto(ChatSseType.INIT_MESSAGE.name(), res));
 
         return emitter;
     }

--- a/src/main/java/com/studypals/domain/chatManage/api/SseChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/SseChatRoomController.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.chatManage.api;
 
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +31,7 @@ public class SseChatRoomController {
     private final ChatRoomService chatRoomService;
     private final SseEmitterManager sseManager;
 
-    @GetMapping("/list")
+    @GetMapping(value = "/list", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter getList(@AuthenticationPrincipal Long userId) {
         SseEmitter emitter = sseManager.createEmitter(userId);
         ChatRoomListRes res = chatRoomService.getChatRoomList(userId);

--- a/src/main/java/com/studypals/domain/chatManage/api/SseChatRoomController.java
+++ b/src/main/java/com/studypals/domain/chatManage/api/SseChatRoomController.java
@@ -1,0 +1,41 @@
+package com.studypals.domain.chatManage.api;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.chatManage.dto.ChatRoomListRes;
+import com.studypals.domain.chatManage.service.ChatRoomService;
+import com.studypals.global.sse.SseEmitterManager;
+import com.studypals.global.sse.SseSendDto;
+
+/**
+ *
+ * <pre>
+ *     - GET /chat/room/list : SSE 기반, 채팅방 리스트 조회
+ * </pre>
+ *
+ * @author jack8
+ * @since 2025-12-10
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/sse/chat/room")
+public class SseChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+    private final SseEmitterManager sseManager;
+
+    @GetMapping("/list")
+    public SseEmitter getList(@AuthenticationPrincipal Long userId) {
+        SseEmitter emitter = sseManager.createEmitter(userId);
+        ChatRoomListRes res = chatRoomService.getChatRoomList(userId);
+        sseManager.sendMessageAsync(userId, new SseSendDto("init-message", res));
+
+        return emitter;
+    }
+}

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepository.java
@@ -91,4 +91,10 @@ public interface ChatMessageCacheRepository {
      * @return 기준 ID를 포함한 이후 구간의 메시지 목록
      */
     List<ChatMessage> fetchFromId(String roomId, String chatId);
+
+    /**
+     * 해당 캐시 내역을 완전히 삭제한다.
+     * @param roomId 삭제할 캐시의 key
+     */
+    void clear(String roomId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
@@ -386,12 +386,22 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
     private ChatMessage toEntity(MapRecord<String, String, String> r) {
         Map<String, String> value = r.getValue();
 
+        String fullKey = r.getStream();
+        String roomId = stripPrefix(fullKey);
+
         return new ChatMessage(
                 decode(value.get(ID_FIELD)),
                 ChatType.valueOf(value.get(TYPE_FIELD)),
-                r.getStream(),
+                roomId,
                 Long.parseLong(value.get(SENDER_FIELD)),
                 value.get(MESSAGE_FIELD));
+    }
+
+    private String stripPrefix(String fullKey) {
+        if (fullKey != null && fullKey.startsWith(KEY_PREFIX)) {
+            return fullKey.substring(KEY_PREFIX.length());
+        }
+        return fullKey;
     }
 
     /**

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
@@ -307,7 +307,7 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
      */
     private ChatroomLatestInfo toLatestInfo(long cnt, ChatMessage chatMessage) {
         return new ChatroomLatestInfo(
-                cnt, chatMessage.getId(), chatMessage.getType(), chatMessage.getMessage(), chatMessage.getSender());
+                cnt, chatMessage.getId(), chatMessage.getType(), chatMessage.getContent(), chatMessage.getSender());
     }
 
     /**
@@ -360,7 +360,7 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
      * @return Stream key 및 recordId 가 설정된 MapRecord
      */
     private MapRecord<String, String, String> recordBuilder(ChatMessage message) {
-        String streamKey = KEY_PREFIX + message.getRoom();
+        String streamKey = KEY_PREFIX + message.getRoomId();
         RecordId recordId = encode(message.getId());
 
         // stream body 에 저장할 필드 구성 (필드 값이 null 인 경우 빈 문자열로 치환)
@@ -368,7 +368,7 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
         body.put(ID_FIELD, Objects.toString(recordId.getValue(), ""));
         body.put(TYPE_FIELD, Objects.toString(message.getType().toString(), ""));
         body.put(SENDER_FIELD, Objects.toString(message.getSender(), ""));
-        body.put(MESSAGE_FIELD, message.getMessage());
+        body.put(MESSAGE_FIELD, message.getContent());
 
         return StreamRecords.<String, String, String>mapBacked(body)
                 .withStreamKey(streamKey)
@@ -447,7 +447,7 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
                     .id(decode(cast(data.get(4))))
                     .type(ChatType.from(cast(data.get(5))))
                     .sender(senderStr == null ? -1L : Long.parseLong(senderStr))
-                    .message(cast(data.get(7)))
+                    .content(cast(data.get(7)))
                     .build();
             this.roomId = streamKey.substring(KEY_PREFIX.length());
         }

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
@@ -193,11 +193,15 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
         List<RoomMeta> needRange = new ArrayList<>();
         for (List<Object> raw : raws) {
             RoomMeta meta = new RoomMeta(raw);
-            meta.targetId = encode(readInfos.get(meta.roomId)).getValue();
+            // meta 에 검색할 targetId 를 삽입
+            String rawId = readInfos.get(meta.roomId);
+            meta.targetId = encode(rawId).getValue();
 
             switch (meta.position()) {
+                    // 변경 - 최근 메시지가 target 인 경우에도, 최신 메시지 정보 반환
                 case BEFORE_OLDEST -> result.put(meta.roomId, toLatestInfo(meta.length, meta.latestChat));
-                case AT_NEWEST, AFTER_NEWEST -> result.put(meta.roomId, createEmptyInfo(meta.position().def));
+                case AFTER_NEWEST -> result.put(meta.roomId, createEmptyInfo(meta.position().def));
+                case AT_NEWEST -> result.put(meta.roomId, toLatestInfo(0, meta.latestChat));
                 case BETWEEN_OLDEST_AND_NEWEST -> needRange.add(meta);
             }
         }

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryImpl.java
@@ -184,7 +184,6 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
     @SuppressWarnings("unchecked")
     public Map<String, ChatroomLatestInfo> countAllToLatest(Map<String, String> readInfos) {
         Map<String, ChatroomLatestInfo> result = new HashMap<>(readInfos.size());
-        StreamOperations<String, String, String> ops = redisTemplate.opsForStream();
         List<String> rooms = new ArrayList<>(readInfos.keySet());
         List<String> streamKeys = rooms.stream().map(id -> KEY_PREFIX + id).toList();
 
@@ -273,6 +272,12 @@ public class ChatMessageCacheRepositoryImpl implements ChatMessageCacheRepositor
         if (result == null || result.isEmpty()) return List.of();
 
         return result.stream().map(this::toEntity).toList();
+    }
+
+    @Override
+    public void clear(String roomId) {
+        String streamKey = KEY_PREFIX + roomId;
+        redisTemplate.delete(streamKey);
     }
 
     /**

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.studypals.domain.chatManage.dao;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
@@ -57,4 +58,19 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
      */
     @Query(value = "{ 'room': ?0, 'id': { $gte: ?1, $lt: ?2 } }", sort = "{ 'id' :  -1 }")
     List<ChatMessage> findRange(String roomId, String from, String to);
+
+    /**
+     * 특정 채팅방에서 최신 메시지 100개를 조회하여 가져옵니다.
+     * <p>
+     * @param roomId 조회할 채팅방 아이디
+     * @return 채팅 메시지 리스트(내림차순)
+     */
+    List<ChatMessage> findTop100ByRoomOrderByIdDesc(String roomId);
+
+    /**
+     * 특정 채팅방에서 최신 메시지 1개를 조회하여 가져옵니다.
+     * @param roomId 조회할 채팅방 아이디
+     * @return 가장 최신 메시지 1개
+     */
+    Optional<ChatMessage> findTopByRoomOrderByIdDesc(String roomId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatMessageRepository.java
@@ -42,7 +42,7 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
      * @param idFrom 기준 메시지 ID (포함)
      * @return 메시지 목록 (ID 내림차순)
      */
-    @Query(value = "{ 'room': ?0, 'id': { $gte: ?1 } }", sort = "{ 'id': -1 }")
+    @Query(value = "{ 'roomId': ?0, 'id': { $gte: ?1 } }", sort = "{ 'id': -1 }")
     List<ChatMessage> findRecent(String roomId, String idFrom);
 
     /**
@@ -56,7 +56,7 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
      * @param to     미포함(upper bound) 기준 메시지 ID
      * @return 범위 내 메시지 목록
      */
-    @Query(value = "{ 'room': ?0, 'id': { $gte: ?1, $lt: ?2 } }", sort = "{ 'id' :  -1 }")
+    @Query(value = "{ 'roomId': ?0, 'id': { $gte: ?1, $lt: ?2 } }", sort = "{ 'id' :  -1 }")
     List<ChatMessage> findRange(String roomId, String from, String to);
 
     /**
@@ -65,12 +65,12 @@ public interface ChatMessageRepository extends MongoRepository<ChatMessage, Stri
      * @param roomId 조회할 채팅방 아이디
      * @return 채팅 메시지 리스트(내림차순)
      */
-    List<ChatMessage> findTop100ByRoomOrderByIdDesc(String roomId);
+    List<ChatMessage> findTop100ByRoomIdOrderByIdDesc(String roomId);
 
     /**
      * 특정 채팅방에서 최신 메시지 1개를 조회하여 가져옵니다.
      * @param roomId 조회할 채팅방 아이디
      * @return 가장 최신 메시지 1개
      */
-    Optional<ChatMessage> findTopByRoomOrderByIdDesc(String roomId);
+    Optional<ChatMessage> findTopByRoomIdOrderByIdDesc(String roomId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepository.java
@@ -67,6 +67,14 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
      */
     List<ChatRoomMember> findAllByMemberId(Long memberId);
 
+    @Query(
+            value =
+                    """
+            SELECT crm.member.id FROM ChatRoomMember crm
+            WHERE crm.chatRoom.id = :roomId
+            """)
+    List<Long> findMemberIdsByRoomId(@Param("roomId") String roomId);
+
     /**
      * 특정 채팅방에 특정 유저가 참여 중인지 조회합니다.
      *

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepository.java
@@ -65,7 +65,14 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
      * @param memberId 유저 ID
      * @return 유저가 속한 모든 ChatRoomMember 기록
      */
-    List<ChatRoomMember> findAllByMemberId(Long memberId);
+    @Query(
+            value =
+                    """
+                SELECT crm FROM ChatRoomMember crm
+                JOIN FETCH crm.chatRoom
+                WHERE crm.member.id = :memberId
+                """)
+    List<ChatRoomMember> findAllByMemberId(@Param("memberId") Long memberId);
 
     @Query(
             value =

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomRepository.java
@@ -37,6 +37,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
      */
     Boolean existsByName(String name);
 
+    /**
+     * 채팅방의 total_member 칼럼을 원자적으로 1 증가시킴으로서 동시성 문제를 방지한다 <br>
+     * Modifying 및 UPDATE 쿼리는 트랜잭션 내에서 실행 시, 해당 row 에 대한 lock 을 걸기에, race condition 을 방지할 수 있다.
+     * @param chatRoomId 채팅방 id, 해당 row 에 대한 쓰기락이 DB 단계에서 생성된다.
+     * @return 변경된 줄 수: 일반적으로 1 -> 갱신 성공, 0 -> 갱신 실패 이다.
+     */
     @Modifying
     @Query(
             """
@@ -46,6 +52,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
     """)
     int increaseChatMember(@Param("chatRoomId") String chatRoomId);
 
+    /**
+     * 채팅방의 total_member 칼럼을 원자적으로 1 증가시킴으로서 동시성 문제를 방지한다 <br>
+     * Modifying 및 UPDATE 쿼리는 트랜잭션 내에서 실행 시, 해당 row 에 대한 lock 을 걸기에, race condition 을 방지할 수 있다.
+     * @param chatRoomId 채팅방 id, 해당 row 에 대한 쓰기락이 DB 단계에서 생성된다.
+     * @return 변경된 줄 수: 일반적으로 1 -> 갱신 성공, 0 -> 갱신 실패 이다.
+     */
     @Modifying
     @Query(
             """

--- a/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomRepository.java
+++ b/src/main/java/com/studypals/domain/chatManage/dao/ChatRoomRepository.java
@@ -1,6 +1,9 @@
 package com.studypals.domain.chatManage.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.chatManage.entity.ChatRoom;
@@ -33,4 +36,22 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, String> {
      * @return 존재하면 true, 아니면 false
      */
     Boolean existsByName(String name);
+
+    @Modifying
+    @Query(
+            """
+        UPDATE ChatRoom cm
+        SET cm.totalMember = cm.totalMember + 1
+        WHERE cm.id = :chatRoomId
+    """)
+    int increaseChatMember(@Param("chatRoomId") String chatRoomId);
+
+    @Modifying
+    @Query(
+            """
+        UPDATE ChatRoom cm
+        SET cm.totalMember = cm.totalMember - 1
+        WHERE cm.id = :chatRoomId AND cm.totalMember > 0
+    """)
+    int decreaseChatMember(@Param("chatRoomId") String chatRoomId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomInfoRes.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomInfoRes.java
@@ -16,7 +16,7 @@ import com.studypals.domain.chatManage.entity.ChatRoomRole;
  */
 @Builder
 public record ChatRoomInfoRes(
-        String id, String name, List<UserInfo> userInfos, List<ChatCursorRes> cursor, List<LoggingMessage> logs) {
+        String roomId, String name, List<UserInfo> userInfos, List<ChatCursorRes> cursor, List<LoggingMessage> logs) {
 
     @Builder
     public record UserInfo(Long userId, ChatRoomRole role, String imageUrl) {}

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomInfoRes.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomInfoRes.java
@@ -16,7 +16,7 @@ import com.studypals.domain.chatManage.entity.ChatRoomRole;
  */
 @Builder
 public record ChatRoomInfoRes(
-        String id, String name, List<UserInfo> userInfos, List<ChatCursorRes> cursor, List<OutgoingMessage> logs) {
+        String id, String name, List<UserInfo> userInfos, List<ChatCursorRes> cursor, List<LoggingMessage> logs) {
 
     @Builder
     public record UserInfo(Long userId, ChatRoomRole role, String imageUrl) {}

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomListRes.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomListRes.java
@@ -12,7 +12,7 @@ public record ChatRoomListRes(List<ChatRoomInfo> rooms) {
             String chatRoomId,
             String chatRoomName,
             String chatRoomUrl,
-            Long joined,
+            Integer totalMember,
             Long unread,
             String lastMessage,
             String messageId,

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomListRes.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomListRes.java
@@ -9,12 +9,12 @@ import java.util.List;
  */
 public record ChatRoomListRes(List<ChatRoomInfo> rooms) {
     public record ChatRoomInfo(
-            String chatRoomId,
-            String chatRoomName,
-            String chatRoomUrl,
+            String roomId,
+            String name,
+            String url,
             Integer totalMember,
             Long unread,
-            String lastMessage,
-            String messageId,
+            String content,
+            String chatId,
             Long sender) {}
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomListRes.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomListRes.java
@@ -1,0 +1,20 @@
+package com.studypals.domain.chatManage.dto;
+
+import java.util.List;
+
+/**
+ * 채팅방 리스트를 반환하기 위해 사용되는 response dto 입니다.
+ * @author jack8
+ * @since 2025-12-04
+ */
+public record ChatRoomListRes(List<ChatRoomInfo> rooms) {
+    public record ChatRoomInfo(
+            String chatRoomId,
+            String chatRoomName,
+            String chatRoomUrl,
+            Long joined,
+            Long unread,
+            String lastMessage,
+            String messageId,
+            Long sender) {}
+}

--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatroomLatestInfo.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatroomLatestInfo.java
@@ -49,7 +49,7 @@ public class ChatroomLatestInfo {
     /**
      * 최신 메시지의 본문 내용.
      */
-    private String message;
+    private String content;
 
     /**
      * 최신 메시지를 보낸 사용자의 ID.

--- a/src/main/java/com/studypals/domain/chatManage/dto/CreateChatRoomDto.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/CreateChatRoomDto.java
@@ -10,4 +10,4 @@ import jakarta.validation.constraints.NotBlank;
  * @author jack8
  * @since 2025-05-10
  */
-public record CreateChatRoomDto(@NotBlank String name) {}
+public record CreateChatRoomDto(@NotBlank String name, String imageUrl) {}

--- a/src/main/java/com/studypals/domain/chatManage/dto/IncomingMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/IncomingMessage.java
@@ -16,6 +16,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class IncomingMessage {
     private ChatType type;
-    private String message;
-    private String room;
+    private String content;
+    private String roomId;
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/LoggingMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/LoggingMessage.java
@@ -4,21 +4,19 @@ import lombok.*;
 
 /**
  * server -> client 로의 메시지 형식을 정의합니다.
- * incomingMessage 에 대해, 일부 정보를 서버에서 추가하여 반환합니다.
+ * OutgoingMessage 에서, roomId 를 제거하여, 그룹화된 채팅 로그 반환 시 필요없는 정보를 제외했습니다.
  *
  * @author jack8
- * @see IncomingMessage
- * @since 2025-06-19
+ * @see OutgoingMessage
+ * @since 2025-12-10
  */
 @Builder
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
-public class OutgoingMessage {
-    @Setter
+public class LoggingMessage {
     private String id;
 
-    private String room;
     private ChatType type;
     private String message;
     private Long sender;

--- a/src/main/java/com/studypals/domain/chatManage/dto/LoggingMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/LoggingMessage.java
@@ -18,6 +18,6 @@ public class LoggingMessage {
     private String id;
 
     private ChatType type;
-    private String message;
+    private String content;
     private Long sender;
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/OutgoingMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/OutgoingMessage.java
@@ -18,8 +18,8 @@ public class OutgoingMessage {
     @Setter
     private String id;
 
-    private String room;
+    private String roomId;
     private ChatType type;
-    private String message;
+    private String content;
     private Long sender;
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/SendChatLogDto.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/SendChatLogDto.java
@@ -1,9 +1,0 @@
-package com.studypals.domain.chatManage.dto;
-
-/**
- * 채팅 내역 전송 요청 시 사용하는 dto 입니다.
- *
- * @author jack8
- * @since 2025-11-18
- */
-public record SendChatLogDto(String sessionId, String roomId, String chatId) {}

--- a/src/main/java/com/studypals/domain/chatManage/dto/SendChatLogReq.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/SendChatLogReq.java
@@ -7,4 +7,4 @@ package com.studypals.domain.chatManage.dto;
  * @see com.studypals.domain.chatManage.api.ChatController ChatController
  * @since 2025-11-20
  */
-public record SendChatLogReq(String room, String chat) {}
+public record SendChatLogReq(String roomId, String chatId) {}

--- a/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatMessageMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import com.studypals.domain.chatManage.dto.IncomingMessage;
+import com.studypals.domain.chatManage.dto.LoggingMessage;
 import com.studypals.domain.chatManage.dto.OutgoingMessage;
 import com.studypals.domain.chatManage.entity.ChatMessage;
 
@@ -20,6 +21,8 @@ public interface ChatMessageMapper {
     OutgoingMessage toOutMessage(IncomingMessage message, Long sender);
 
     OutgoingMessage toOutMessage(ChatMessage message);
+
+    LoggingMessage toLoggingMessage(ChatMessage message);
 
     ChatMessage toEntity(IncomingMessage message, String id, Long sender);
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatRoomMapper.java
@@ -45,7 +45,7 @@ public interface ChatRoomMapper {
                 chatRoomMember.getChatRoom().getImageUrl(),
                 chatRoomMember.getChatRoom().getTotalMember(),
                 info != null ? info.getCnt() : -1,
-                info != null ? info.getMessage() : null,
+                info != null ? info.getContent() : null,
                 info != null ? info.getId() : null,
                 info != null ? info.getSender() : null);
     }

--- a/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatRoomMapper.java
@@ -1,9 +1,13 @@
 package com.studypals.domain.chatManage.dto.mapper;
 
+import java.util.Map;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
+import com.studypals.domain.chatManage.dto.ChatRoomListRes;
+import com.studypals.domain.chatManage.dto.ChatroomLatestInfo;
 import com.studypals.domain.chatManage.entity.ChatRoomMember;
 
 /**
@@ -20,4 +24,29 @@ public interface ChatRoomMapper {
     @Mapping(target = "userId", source = "member.id")
     @Mapping(target = "imageUrl", source = "member.imageUrl")
     ChatRoomInfoRes.UserInfo toDto(ChatRoomMember entity);
+
+    /**
+     * 단일 ChatRoomMember 객체와 최신 메시지 조회 결과를 기반으로
+     * ChatRoomInfo DTO를 생성한다.
+     * info 가 없으면 언리드 개수는 -1, 메시지/보낸이는 null 로 설정한다.
+     *
+     * @param chatRoomMember 사용자가 참여한 채팅방 정보
+     * @param latestInfos 채팅방별 최신 메시지 및 언리드 정보
+     * @return ChatRoomListRes.ChatRoomInfo 변환 결과
+     */
+    default ChatRoomListRes.ChatRoomInfo toChatRoomInfo(
+            ChatRoomMember chatRoomMember, Map<String, ChatroomLatestInfo> latestInfos) {
+        String chatRoomId = chatRoomMember.getChatRoom().getId();
+        ChatroomLatestInfo info = latestInfos.get(chatRoomId);
+
+        return new ChatRoomListRes.ChatRoomInfo(
+                chatRoomId,
+                chatRoomMember.getChatRoom().getName(),
+                chatRoomMember.getChatRoom().getImageUrl(),
+                chatRoomMember.getChatRoom().getTotalMember(),
+                info != null ? info.getCnt() : -1,
+                info != null ? info.getMessage() : null,
+                info != null ? info.getId() : null,
+                info != null ? info.getSender() : null);
+    }
 }

--- a/src/main/java/com/studypals/domain/chatManage/entity/ChatCacheValue.java
+++ b/src/main/java/com/studypals/domain/chatManage/entity/ChatCacheValue.java
@@ -1,0 +1,25 @@
+package com.studypals.domain.chatManage.entity;
+
+import com.studypals.domain.chatManage.worker.ChatRoomReader;
+import com.studypals.domain.chatManage.worker.ChatRoomWriter;
+import com.studypals.domain.memberManage.entity.Member;
+
+/**
+ * 채팅방 관련 캐싱 시 사용되는 value(prefix 에 들어가는 값)를 정의합니다.
+ *
+ * @author jack8
+ * @see com.studypals.domain.chatManage.worker.ChatRoomReader ChatRoomReader
+ * @since 2025-12-04
+ */
+public class ChatCacheValue {
+
+    /**
+     * @Cacheable {@link ChatRoomReader#findJoinedMemberId(String) }
+     *
+     * @CacheEvict
+     * {@link ChatRoomWriter#leave(ChatRoom, Member) } <br>
+     * {@link  ChatRoomWriter#join(ChatRoom, Member) } <br>
+     * {@link  ChatRoomWriter#joinAsAdmin(ChatRoom, Member)} <br>
+     */
+    public static final String JOINED_MEMBER = "joinedMember";
+}

--- a/src/main/java/com/studypals/domain/chatManage/entity/ChatMessage.java
+++ b/src/main/java/com/studypals/domain/chatManage/entity/ChatMessage.java
@@ -30,9 +30,9 @@ public class ChatMessage {
     private String id;
 
     private ChatType type;
-    private String room;
+    private String roomId;
     private Long sender;
-    private String message;
+    private String content;
 
     @RequiredArgsConstructor
     @Getter

--- a/src/main/java/com/studypals/domain/chatManage/entity/ChatRoom.java
+++ b/src/main/java/com/studypals/domain/chatManage/entity/ChatRoom.java
@@ -40,4 +40,10 @@ public class ChatRoom {
     @Column(name = "created_date")
     @CreatedDate
     private LocalDate createdDate;
+
+    @Column(name = "image_url", nullable = true)
+    private String imageUrl;
+
+    @Column(name = "joined", nullable = false)
+    private Long joined;
 }

--- a/src/main/java/com/studypals/domain/chatManage/entity/ChatRoom.java
+++ b/src/main/java/com/studypals/domain/chatManage/entity/ChatRoom.java
@@ -44,6 +44,6 @@ public class ChatRoom {
     @Column(name = "image_url", nullable = true)
     private String imageUrl;
 
-    @Column(name = "joined", nullable = false)
-    private Long joined;
+    @Column(name = "totalMember", nullable = false, columnDefinition = "INTEGER DEFAULT 1")
+    private Integer totalMember;
 }

--- a/src/main/java/com/studypals/domain/chatManage/entity/ChatSseType.java
+++ b/src/main/java/com/studypals/domain/chatManage/entity/ChatSseType.java
@@ -1,0 +1,19 @@
+package com.studypals.domain.chatManage.entity;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * SSE type(name) 에 들어가는 내용을 enum 으로 구조화하였습니다.
+ *
+ * @author jack8
+ * @see com.studypals.global.sse.SseEmitterManager SseEmitterManager
+ * @since 2025-12-11
+ */
+@RequiredArgsConstructor
+public enum ChatSseType {
+    CONNECT("connect"),
+    INIT_MESSAGE("init-message"),
+    NEW_MESSAGE("new-message");
+
+    private final String name;
+}

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatRoomService.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatRoomService.java
@@ -29,5 +29,10 @@ public interface ChatRoomService {
      */
     ChatRoomInfoRes getChatRoomInfo(Long userId, String chatRoomId, String chatId);
 
+    /**
+     * 해당 사용자가 소속된 채팅방에 대한, 각 채팅방 정보, 언리드 카운트, 마지막 메시지 데이터 등을 리스트로 반환합니다.
+     * @param userId 검색할 사용자의 userId
+     * @return 소속된 채팅방 리스트 데이터
+     */
     ChatRoomListRes getChatRoomList(Long userId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatRoomService.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.studypals.domain.chatManage.service;
 
 import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
+import com.studypals.domain.chatManage.dto.ChatRoomListRes;
 
 /**
  * 채팅방에 대한 기본적인 조작 로직을 정의한 인터페이스입니다. 다만, 대부분의 로직은 Group 에서 수행됩니다.(생성,삭제, 유저 참여 등)
@@ -27,4 +28,6 @@ public interface ChatRoomService {
      * @return 채팅방 정보 및 해당 채팅방에 소속된 유저의 정보 리스트
      */
     ChatRoomInfoRes getChatRoomInfo(Long userId, String chatRoomId, String chatId);
+
+    ChatRoomListRes getChatRoomList(Long userId);
 }

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
@@ -92,7 +92,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // DB 에 저장된 각 멤버의 마지막 읽은 메시지 ID를 기반으로 기본 커서 맵 구성
         Map<Long, String> cursorData = new HashMap<>();
         for (ChatRoomMember chatRoomMember : members) {
-            cursorData.put(chatRoomMember.getId(), chatRoomMember.getLastReadMessage());
+            cursorData.put(chatRoomMember.getMember().getId(), chatRoomMember.getLastReadMessage());
         }
 
         // 캐시에 저장된 최신 커서 정보로 덮어쓰기 (실시간 갱신분 반영)
@@ -104,8 +104,8 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 .toList();
 
         // 기준 chatId 이후의 채팅 로그를 조회하고, 전송용 OutgoingMessage DTO 리스트로 변환
-        List<OutgoingMessage> logs = chatMessageReader.getChatLog(chatRoomId, chatId).stream()
-                .map(chatMessageMapper::toOutMessage)
+        List<LoggingMessage> logs = chatMessageReader.getChatLog(chatRoomId, chatId).stream()
+                .map(chatMessageMapper::toLoggingMessage)
                 .toList();
 
         // 채팅방 정보, 유저 정보, 커서, 채팅 로그를 모두 조합하여 최종 응답 생성

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
@@ -163,39 +163,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         // 응답 DTO 구성
         List<ChatRoomListRes.ChatRoomInfo> infos = chatRoomMembers.stream()
-                .map(crm -> toChatRoomInfo(crm, latestInfos))
+                .map(crm -> chatRoomMapper.toChatRoomInfo(crm, latestInfos))
                 .toList();
 
         return new ChatRoomListRes(infos);
-    }
-
-    /**
-     * 단일 ChatRoomMember 객체와 최신 메시지 조회 결과를 기반으로
-     * ChatRoomInfo DTO를 생성한다.
-     * info 가 없으면 언리드 개수는 -1, 메시지/보낸이는 null 로 설정한다.
-     *
-     * @param chatRoomMember 사용자가 참여한 채팅방 정보
-     * @param latestInfos 채팅방별 최신 메시지 및 언리드 정보
-     * @return ChatRoomListRes.ChatRoomInfo 변환 결과
-     */
-    private ChatRoomListRes.ChatRoomInfo toChatRoomInfo(
-            ChatRoomMember chatRoomMember, Map<String, ChatroomLatestInfo> latestInfos) {
-        String chatRoomId = chatRoomMember.getChatRoom().getId();
-        ChatroomLatestInfo info = latestInfos.get(chatRoomId);
-
-        Long unreadCount = (info != null) ? info.getCnt() : -1;
-        String lastMessage = (info != null) ? info.getMessage() : null;
-        String messageId = (info != null) ? info.getId() : null;
-        Long lastSender = (info != null) ? info.getSender() : null;
-
-        return new ChatRoomListRes.ChatRoomInfo(
-                chatRoomId,
-                chatRoomMember.getChatRoom().getName(),
-                chatRoomMember.getChatRoom().getImageUrl(),
-                chatRoomMember.getChatRoom().getTotalMember(),
-                unreadCount,
-                lastMessage,
-                messageId,
-                lastSender);
     }
 }

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
@@ -110,7 +110,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         // 채팅방 정보, 유저 정보, 커서, 채팅 로그를 모두 조합하여 최종 응답 생성
         return ChatRoomInfoRes.builder()
-                .id(chatRoomId)
+                .roomId(chatRoomId)
                 .name(chatRoom.getName())
                 .userInfos(members.stream().map(chatRoomMapper::toDto).toList())
                 .cursor(chatCursorRes)

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatRoomServiceImpl.java
@@ -169,7 +169,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         String chatRoomId = chatRoomMember.getChatRoom().getId();
         ChatroomLatestInfo info = latestInfos.get(chatRoomId);
 
-        long unreadCount = (info != null) ? info.getCnt() : -1;
+        Long unreadCount = (info != null) ? info.getCnt() : -1;
         String lastMessage = (info != null) ? info.getMessage() : null;
         Long lastSender = (info != null) ? info.getSender() : null;
 
@@ -177,7 +177,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 chatRoomId,
                 chatRoomMember.getChatRoom().getName(),
                 chatRoomMember.getChatRoom().getImageUrl(),
-                chatRoomMember.getChatRoom().getJoined(),
+                chatRoomMember.getChatRoom().getTotalMember(),
                 unreadCount,
                 lastMessage,
                 lastMessage,

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import com.studypals.domain.chatManage.dto.*;
 import com.studypals.domain.chatManage.dto.mapper.ChatMessageMapper;
 import com.studypals.domain.chatManage.entity.ChatMessage;
+import com.studypals.domain.chatManage.entity.ChatSseType;
 import com.studypals.domain.chatManage.worker.*;
 import com.studypals.global.exceptions.errorCode.ChatErrorCode;
 import com.studypals.global.exceptions.exception.ChatException;
@@ -77,7 +78,8 @@ public class ChatServiceImpl implements ChatService {
 
         // 소속 멤버를 찾아, SSE 로 메시지 전송
         List<Long> memberIds = chatRoomReader.findJoinedMemberId(message.getRoomId());
-        memberIds.forEach(t -> sseManager.sendMessageAsync(t, new SseSendDto("new-message", outgoingMessage)));
+        memberIds.forEach(
+                t -> sseManager.sendMessageAsync(t, new SseSendDto(ChatSseType.NEW_MESSAGE.name(), outgoingMessage)));
         // 영속화용 엔티티로 변환 후 비동기 저장 파이프라인에 위임
         ChatMessage entity = chatMessageMapper.toEntity(message, id, userId);
         chatMessagePipeline.publish(entity);

--- a/src/main/java/com/studypals/domain/chatManage/service/ChatServiceImpl.java
+++ b/src/main/java/com/studypals/domain/chatManage/service/ChatServiceImpl.java
@@ -73,10 +73,10 @@ public class ChatServiceImpl implements ChatService {
         outgoingMessage.setId(id);
 
         // STOMP 브로커로 해당 채팅방 구독자에게 브로드캐스트
-        template.convertAndSend(DESTINATION_PREFIX + message.getRoom(), outgoingMessage);
+        template.convertAndSend(DESTINATION_PREFIX + message.getRoomId(), outgoingMessage);
 
         // 소속 멤버를 찾아, SSE 로 메시지 전송
-        List<Long> memberIds = chatRoomReader.findJoinedMemberId(message.getRoom());
+        List<Long> memberIds = chatRoomReader.findJoinedMemberId(message.getRoomId());
         memberIds.forEach(t -> sseManager.sendMessageAsync(t, new SseSendDto("new-message", outgoingMessage)));
         // 영속화용 엔티티로 변환 후 비동기 저장 파이프라인에 위임
         ChatMessage entity = chatMessageMapper.toEntity(message, id, userId);
@@ -95,7 +95,7 @@ public class ChatServiceImpl implements ChatService {
     public void readMessage(Long userId, IncomingMessage message) {
         // READ 타입인 경우에만 읽음 커서 업데이트 수행
         if (message.getType().equals(ChatType.READ)) {
-            chatStateUpdater.update(new ChatUpdateDto(message.getRoom(), userId, message.getMessage()));
+            chatStateUpdater.update(new ChatUpdateDto(message.getRoomId(), userId, message.getContent()));
         }
     }
 

--- a/src/main/java/com/studypals/domain/chatManage/worker/ChatMessageReader.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ChatMessageReader.java
@@ -114,7 +114,7 @@ public class ChatMessageReader {
             }
 
             if (cached.getCnt() < 0) {
-                Optional<ChatMessage> latestMessageOp = messageRepository.findTopByRoomOrderByIdDesc(entry.getKey());
+                Optional<ChatMessage> latestMessageOp = messageRepository.findTopByRoomIdOrderByIdDesc(entry.getKey());
 
                 if (latestMessageOp.isEmpty()) {
                     it.remove();
@@ -130,10 +130,10 @@ public class ChatMessageReader {
                     // 기준 ID == 최신 ID → unread = 0, 메시지 1개만 캐시에
                     cacheRepository.save(message);
                     entry.setValue(new ChatroomLatestInfo(
-                            0, message.getId(), message.getType(), message.getMessage(), message.getSender()));
+                            0, message.getId(), message.getType(), message.getContent(), message.getSender()));
                 } else {
                     List<ChatMessage> messages =
-                            new ArrayList<>(messageRepository.findTop100ByRoomOrderByIdDesc(roomId));
+                            new ArrayList<>(messageRepository.findTop100ByRoomIdOrderByIdDesc(roomId));
                     Collections.reverse(messages);
                     cacheRepository.clear(roomId);
                     cacheRepository.saveAll(messages);
@@ -151,14 +151,14 @@ public class ChatMessageReader {
                     if (unread > 100) unread = 100;
 
                     entry.setValue(new ChatroomLatestInfo(
-                            unread, message.getId(), message.getType(), message.getMessage(), message.getSender()));
+                            unread, message.getId(), message.getType(), message.getContent(), message.getSender()));
                 }
             } else {
                 long cnt = cached.getCnt();
                 cnt = cnt > 100 ? 100 : cnt;
 
                 ChatroomLatestInfo capped = new ChatroomLatestInfo(
-                        cnt, cached.getId(), cached.getType(), cached.getMessage(), cached.getSender());
+                        cnt, cached.getId(), cached.getType(), cached.getContent(), cached.getSender());
 
                 entry.setValue(capped); // 구조 변경 없이 value만 교체
             }

--- a/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomReader.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomReader.java
@@ -3,11 +3,14 @@ package com.studypals.domain.chatManage.worker;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.cache.annotation.Cacheable;
+
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.chatManage.dao.ChatRoomMemberRepository;
 import com.studypals.domain.chatManage.dao.ChatRoomRepository;
 import com.studypals.domain.chatManage.dao.UserLastReadMessageRepository;
+import com.studypals.domain.chatManage.entity.ChatCacheValue;
 import com.studypals.domain.chatManage.entity.ChatRoom;
 import com.studypals.domain.chatManage.entity.ChatRoomMember;
 import com.studypals.domain.chatManage.entity.UserLastReadMessage;
@@ -83,5 +86,17 @@ public class ChatRoomReader {
      */
     public UserLastReadMessage getCachedCursor(String roomId) {
         return userLastReadMessageRepository.findById(roomId).orElse(new UserLastReadMessage(roomId, Map.of()));
+    }
+
+    /**
+     * 현재 채팅방에 소속된 member 의 id 를 추출하여 리스트로 받습니다. redis cache 로 캐싱된 메서드 이기에
+     * 파라미터와 반환타입을 primitive 혹은 그에 준한 타입으로 사용하였습니다.
+     * @param chatRoomId 채팅방 아이디
+     * @return 해당 채팅방에 소속된 member id
+     * @Cacheable {@link ChatCacheValue}
+     */
+    @Cacheable(value = ChatCacheValue.JOINED_MEMBER, key = "#chatRoomId")
+    public List<Long> findJoinedMemberId(String chatRoomId) {
+        return chatRoomMemberRepository.findMemberIdsByRoomId(chatRoomId);
     }
 }

--- a/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomReader.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomReader.java
@@ -2,6 +2,7 @@ package com.studypals.domain.chatManage.worker;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.Cacheable;
 
@@ -70,7 +71,7 @@ public class ChatRoomReader {
     }
 
     /**
-     * 해당 유저가 소속한 chatRoomMember 엔티티 리스트를 반환합니다. 어쩌면 fetch join 타입으로 가져와야 할 수 도 있습니다.
+     * 해당 유저가 소속한 chatRoomMember 엔티티 리스트를 반환합니다. ChatRoom 이 FECTH JOIN 된 결과를 반환합니다.
      * @param member 검색할 멤버 엔티티
      * @return chatRoomMember 엔티티 리스트
      */
@@ -86,6 +87,12 @@ public class ChatRoomReader {
      */
     public UserLastReadMessage getCachedCursor(String roomId) {
         return userLastReadMessageRepository.findById(roomId).orElse(new UserLastReadMessage(roomId, Map.of()));
+    }
+
+    public Map<String, Map<String, String>> getEachUserCursor(Long userId, List<String> roomIds) {
+        Map<String, List<String>> param =
+                roomIds.stream().collect(Collectors.toMap(t -> t, t -> List.of(userId.toString())));
+        return userLastReadMessageRepository.findHashFieldsById(param);
     }
 
     /**

--- a/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomWriter.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomWriter.java
@@ -119,7 +119,7 @@ public class ChatRoomWriter {
      */
     private void internalJoin(ChatRoom chatRoom, Member member, ChatRoomRole roomRole) {
 
-        // total member 증가 로직
+        // total member 증가 로직 - 원자적 실행 및 갱신 실패 시 오류 반환
         int updated = chatRoomRepository.increaseChatMember(chatRoom.getId());
         if (updated == 0) {
             throw new ChatException(

--- a/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomWriter.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ChatRoomWriter.java
@@ -1,10 +1,13 @@
 package com.studypals.domain.chatManage.worker;
 
+import org.springframework.cache.annotation.CacheEvict;
+
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.chatManage.dao.ChatRoomMemberRepository;
 import com.studypals.domain.chatManage.dao.ChatRoomRepository;
 import com.studypals.domain.chatManage.dto.CreateChatRoomDto;
+import com.studypals.domain.chatManage.entity.ChatCacheValue;
 import com.studypals.domain.chatManage.entity.ChatRoom;
 import com.studypals.domain.chatManage.entity.ChatRoomMember;
 import com.studypals.domain.chatManage.entity.ChatRoomRole;
@@ -56,6 +59,7 @@ public class ChatRoomWriter {
      * @param member 참가할 멤버
      * @throws ChatException CHAT_ROOM_JOIN_FAIL / 채팅방 참여가 실패
      */
+    @CacheEvict(value = ChatCacheValue.JOINED_MEMBER, key = "#member.id")
     public void joinAsAdmin(ChatRoom chatRoom, Member member) {
         internalJoin(chatRoom, member, ChatRoomRole.ADMIN);
     }
@@ -66,6 +70,7 @@ public class ChatRoomWriter {
      * @param member 참가할 멤버
      * @throws ChatException CHAT_ROOM_JOIN_FAIL / 채팅방 참여가 실패
      */
+    @CacheEvict(value = ChatCacheValue.JOINED_MEMBER, key = "#member.id")
     public void join(ChatRoom chatRoom, Member member) {
         internalJoin(chatRoom, member, ChatRoomRole.MEMBER);
     }
@@ -77,6 +82,7 @@ public class ChatRoomWriter {
      * @throws ChatException CHAT_ROOM_NOT_FOUND / 해당 member 가 속한 chatroom 을 찾을 수 없음(속해있지 않거나,id가 잘못됨)
      * @throws ChatException CHAT_ROOM_ADMIN_LEAVE / admin 이 채팅방 탈퇴를 시도하는 경우
      */
+    @CacheEvict(value = ChatCacheValue.JOINED_MEMBER, key = "#member.id")
     public void leave(ChatRoom chatRoom, Member member) {
         ChatRoomMember chatRoomMember = chatRoomMemberRepository
                 .findByChatRoomIdAndMemberId(chatRoom.getId(), member.getId())

--- a/src/main/java/com/studypals/domain/chatManage/worker/ChatStateUpdater.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ChatStateUpdater.java
@@ -193,8 +193,8 @@ public class ChatStateUpdater {
             Map<String, String> userLastReads = entry.getValue();
 
             try {
-                OutgoingMessage outgoingMessage =
-                        new OutgoingMessage(null, ChatType.STAT, objectMapper.writeValueAsString(userLastReads), null);
+                OutgoingMessage outgoingMessage = new OutgoingMessage(
+                        null, roomId, ChatType.STAT, objectMapper.writeValueAsString(userLastReads), null);
                 template.convertAndSend(DESTINATION_PREFIX + roomId, outgoingMessage);
             } catch (JsonProcessingException e) {
                 e.printStackTrace();

--- a/src/main/java/com/studypals/domain/chatManage/worker/ReactiveChatSaveWorker.java
+++ b/src/main/java/com/studypals/domain/chatManage/worker/ReactiveChatSaveWorker.java
@@ -86,7 +86,7 @@ public class ReactiveChatSaveWorker {
 
             // 채팅방에 대해 - 가장 마지막 메시지를 저장합니다. 모든 메시지에 대해, 크기 비교를 통해 더 큰 값이(최신값) 들어옵니다.
             for (ChatMessage msg : savedMessages) {
-                latestByRoom.merge(msg.getRoom(), msg, (a, b) -> a.getId().compareTo(b.getId()) < 0 ? b : a);
+                latestByRoom.merge(msg.getRoomId(), msg, (a, b) -> a.getId().compareTo(b.getId()) < 0 ? b : a);
             }
             cacheRepository.saveAll(savedMessages); // 캐시에 해당 데이터를 전부 저장합니다.
 

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupRepository.java
@@ -31,4 +31,13 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
         WHERE g.id = :groupId AND g.totalMember < g.maxMember
     """)
     int increaseGroupMember(@Param("groupId") Long groupId);
+
+    @Modifying
+    @Query(
+            """
+        UPDATE Group g
+        SET g.totalMember = g.totalMember - 1
+        WHERE g.id = :groupId AND g.totalMember > 0
+    """)
+    int decreaseGroupMember(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/studypals/domain/groupManage/dto/CreateGroupReq.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/CreateGroupReq.java
@@ -22,4 +22,6 @@ public record CreateGroupReq(
         @NotBlank String tag,
         @Min(10) @Max(100) Integer maxMember,
         Boolean isOpen,
-        Boolean isApprovalRequired) {}
+        Boolean isApprovalRequired,
+        // since 12-05 sanghyeok
+        String imageUrl) {}

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -58,7 +58,7 @@ public class GroupServiceImpl implements GroupService {
         groupMemberWriter.createLeader(member, group);
 
         // 채팅방 생성
-        CreateChatRoomDto createChatRoomDto = new CreateChatRoomDto(dto.name());
+        CreateChatRoomDto createChatRoomDto = new CreateChatRoomDto(dto.name(), dto.imageUrl());
         ChatRoom chatRoom = chatRoomWriter.create(createChatRoomDto);
         chatRoomWriter.joinAsAdmin(chatRoom, member);
         group.setChatRoom(chatRoom);

--- a/src/main/java/com/studypals/global/exceptions/errorCode/ChatErrorCode.java
+++ b/src/main/java/com/studypals/global/exceptions/errorCode/ChatErrorCode.java
@@ -29,6 +29,7 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_SAVE_FAIL(ResponseCode.CHAT_ROOM_CREATE, HttpStatus.INTERNAL_SERVER_ERROR, "can't save chatroom"),
     CHAT_ROOM_JOIN_FAIL(ResponseCode.CHAT_ROOM_JOIN, HttpStatus.INTERNAL_SERVER_ERROR, "can't join to chatroom"),
     CHAT_ROOM_ADMIN_LEAVE(ResponseCode.CHAT_ROOM_LEAVE, HttpStatus.BAD_REQUEST, "admin can't leave chatRoom"),
+    CHAT_ROOM_LEAVE(ResponseCode.CHAT_ROOM_LEAVE, HttpStatus.BAD_REQUEST, "can't leave chatRoom"),
     CHAT_ROOM_PERMISSION_DENIED(
             ResponseCode.CHAT_ROOM_SEARCH, HttpStatus.FORBIDDEN, "you have no permission to access this behavior"),
 

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/ExceptionHandlerOrder.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/ExceptionHandlerOrder.java
@@ -9,6 +9,7 @@ package com.studypals.global.exceptions.exceptionHandler;
  * @since 2025-04-01
  */
 public class ExceptionHandlerOrder {
+    public static final int SSE_EXCEPTION_HANDLER = 0;
     public static final int DEFAULT_EXCEPTION_HANDLER = 1;
     public static final int GLOBAL_EXCEPTION_HANDLER = 2;
 }

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
@@ -1,0 +1,76 @@
+package com.studypals.global.exceptions.exceptionHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.google.common.net.HttpHeaders;
+import com.studypals.global.exceptions.exception.BaseException;
+
+/**
+ * SSE 과정 중 발생하는 예외를 처리하는 예외 헨들러입니다.
+ *
+ * @author jack8
+ * @since 2025-12-05
+ */
+@Slf4j
+@RestControllerAdvice
+@Order(0)
+public class SseExceptionHandler {
+
+    private boolean isSseRequest(HttpServletRequest request) {
+        String accept = request.getHeader(HttpHeaders.ACCEPT);
+        if (accept != null && accept.contains(MediaType.TEXT_EVENT_STREAM_VALUE)) {
+            return true;
+        }
+        String contentType = request.getHeader(HttpHeaders.CONTENT_TYPE);
+        return contentType != null && contentType.contains(MediaType.TEXT_EVENT_STREAM_VALUE);
+    }
+
+    /**
+     * 도메인 예외 (인증/인가, 비즈니스 에러 등)
+     * - SSE 요청이면: 상태코드만 내려주고 body 없음 → EventSource.onerror 에서 감지
+     * - SSE 아니면: 다른 Handler 가 처리하도록 넘김
+     */
+    @ExceptionHandler(BaseException.class) // 너네 공통 예외 타입
+    public void handleSseBaseException(BaseException ex, HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        if (!isSseRequest(request)) {
+            // SSE 요청이 아니면 이 핸들러는 패스 → 다음 ExceptionResolver 에게 맡김
+            throw ex;
+        }
+
+        log.warn("SSE business error: code={}, message={}", ex.getErrorCode(), ex.getMessage());
+
+        response.resetBuffer(); // 혹시 쓰던 버퍼 있으면 비움
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        // body 없이 끝냄 → HttpMessageConverter 안 타서 CommonResponse 문제 없음
+        response.flushBuffer();
+    }
+
+    /**
+     * 예측하지 못한 서버 내부 에러
+     * - SSE 요청이면: 500만 내려주고 body 없음
+     * - SSE 아니면: 다른 Handler 에게 넘김
+     */
+    @ExceptionHandler(Exception.class)
+    public void handleSseGenericException(Exception ex, HttpServletRequest request, HttpServletResponse response)
+            throws Exception {
+        if (!isSseRequest(request)) {
+            throw ex;
+        }
+
+        log.error("SSE internal error", ex);
+
+        response.resetBuffer();
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        response.flushBuffer();
+    }
+}

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
@@ -21,7 +21,7 @@ import com.studypals.global.exceptions.exception.BaseException;
  * @since 2025-12-05
  */
 @Slf4j
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.global.sse")
 @Order(0)
 public class SseExceptionHandler {
 

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
@@ -23,7 +23,7 @@ import com.studypals.global.exceptions.exception.BaseException;
  */
 @Slf4j
 @RestControllerAdvice(basePackages = "com.studypals.global.sse", basePackageClasses = SseChatRoomController.class)
-@Order(0)
+@Order(ExceptionHandlerOrder.SSE_EXCEPTION_HANDLER)
 public class SseExceptionHandler {
 
     private boolean isSseRequest(HttpServletRequest request) {
@@ -50,9 +50,8 @@ public class SseExceptionHandler {
 
         log.warn("SSE business error: code={}, message={}", ex.getErrorCode(), ex.getMessage());
 
-        response.resetBuffer(); // 혹시 쓰던 버퍼 있으면 비움
+        response.resetBuffer();
         response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
-        // body 없이 끝냄 → HttpMessageConverter 안 타서 CommonResponse 문제 없음
         response.flushBuffer();
     }
 

--- a/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
+++ b/src/main/java/com/studypals/global/exceptions/exceptionHandler/SseExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 
 import com.google.common.net.HttpHeaders;
+import com.studypals.domain.chatManage.api.SseChatRoomController;
 import com.studypals.global.exceptions.exception.BaseException;
 
 /**
@@ -21,7 +22,7 @@ import com.studypals.global.exceptions.exception.BaseException;
  * @since 2025-12-05
  */
 @Slf4j
-@RestControllerAdvice(basePackages = "com.global.sse")
+@RestControllerAdvice(basePackages = "com.studypals.global.sse", basePackageClasses = SseChatRoomController.class)
 @Order(0)
 public class SseExceptionHandler {
 

--- a/src/main/java/com/studypals/global/redis/RedisCacheConfig.java
+++ b/src/main/java/com/studypals/global/redis/RedisCacheConfig.java
@@ -2,7 +2,9 @@ package com.studypals.global.redis;
 
 import java.time.Duration;
 
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -24,6 +26,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
  * @see com.studypals.domain.chatManage.entity.ChatCacheValue ChatCacheValue
  * @since 2025-12-04
  */
+@Configuration
+@EnableCaching
 public class RedisCacheConfig {
 
     @Bean

--- a/src/main/java/com/studypals/global/redis/RedisCacheConfig.java
+++ b/src/main/java/com/studypals/global/redis/RedisCacheConfig.java
@@ -1,0 +1,45 @@
+package com.studypals.global.redis;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * redis cache 관련 설정입니다. <br>
+ * <pre>
+ *     - TTL : 10분
+ *     - Null 저장 안함
+ *     - prefix : "cache:[value]::[key]"
+ *     - key 직렬화기 : StringRedisSerializer
+ *     - value 직렬화기 : GenericJackson2JsonRedisSerializer
+ * </pre>
+ *
+ * @author jack8
+ * @see com.studypals.domain.chatManage.entity.ChatCacheValue ChatCacheValue
+ * @since 2025-12-04
+ */
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10)) // 기본 TTL
+                .disableCachingNullValues()
+                .computePrefixWith(cacheName -> "cache:" + cacheName + ":") // prefix
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/java/com/studypals/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/studypals/global/security/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.studypals.global.security.config;
 
+import jakarta.servlet.DispatcherType;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -12,6 +14,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.DispatcherTypeRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,6 +46,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http, JwtUtils jwtUtils) throws Exception {
         http.httpBasic(AbstractHttpConfigurer::disable)
+                .securityMatcher(new NegatedRequestMatcher(new DispatcherTypeRequestMatcher(DispatcherType.ASYNC)))
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((auth) -> {

--- a/src/main/java/com/studypals/global/sse/SSEConfig.java
+++ b/src/main/java/com/studypals/global/sse/SSEConfig.java
@@ -1,0 +1,39 @@
+package com.studypals.global.sse;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * {@code WebMvczConfigurer} 를 상속받아, SSE 에 대한 설정을 작성한 클래스입니다.
+ * <br>
+ * 기존의 SSE 스레드 관리 방식 대신, 스레드 풀을 등록하였습니다.
+ * 스레드 풀의 core/max 및 queue 사이즈 정의 하였습니다.
+ *
+ * @author jack8
+ * @since 2025-12-04
+ */
+@Configuration
+@EnableAsync
+public class SSEConfig implements WebMvcConfigurer {
+
+    @Bean(name = "sseTaskExecutor")
+    public ThreadPoolTaskExecutor sseTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("sse-");
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(100);
+        executor.setQueueCapacity(10_000);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setDefaultTimeout(0);
+        configurer.setTaskExecutor(sseTaskExecutor());
+    }
+}

--- a/src/main/java/com/studypals/global/sse/SSEConfig.java
+++ b/src/main/java/com/studypals/global/sse/SSEConfig.java
@@ -24,8 +24,8 @@ public class SSEConfig implements WebMvcConfigurer {
     public ThreadPoolTaskExecutor sseTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setThreadNamePrefix("sse-");
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(100);
+        executor.setCorePoolSize(8);
+        executor.setMaxPoolSize(60);
         executor.setQueueCapacity(10_000);
         executor.initialize();
         return executor;

--- a/src/main/java/com/studypals/global/sse/SseEmitterManager.java
+++ b/src/main/java/com/studypals/global/sse/SseEmitterManager.java
@@ -88,6 +88,7 @@ public class SseEmitterManager {
      * @param dto 메시지 내용(타입 및 데이터)
      */
     public void sendMessageAsync(Long userId, SseSendDto dto) {
+        if (!userSessions.containsKey(userId)) return;
         taskExecutor.execute(() -> sendMessageInternal(userId, dto));
     }
 

--- a/src/main/java/com/studypals/global/sse/SseEmitterManager.java
+++ b/src/main/java/com/studypals/global/sse/SseEmitterManager.java
@@ -1,0 +1,156 @@
+package com.studypals.global.sse;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 유저별 SSE 세션을 관리하는 매니저.
+ * <pr>
+ * - 하나의 유저는 여러 SSE 연결을 가질 수 있음(브라우저 탭, 디바이스 등)
+ * - 연결마다 고유 sessionId(UUID) 부여
+ * - SSE 연결 종료/오류/타임아웃 시 자동 정리
+ * - 특정 유저에게 여러 SSE 세션으로 동시에 이벤트를 전송
+ * </pr>
+ *
+ * <p><b>외부 모듈:</b><br>
+ * SSE
+ *
+ * @author jack8
+ * @since 2025-12-04
+ */
+@Component
+@Slf4j
+public class SseEmitterManager {
+
+    /** 유저ID → 세션ID 집합 */
+    private final Map<Long, Set<String>> userSessions = new ConcurrentHashMap<>();
+
+    /** 세션ID → SseEmitter */
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    private final ThreadPoolTaskExecutor taskExecutor;
+
+    public SseEmitterManager(@Qualifier("sseTaskExecutor") ThreadPoolTaskExecutor taskExecutor) {
+        this.taskExecutor = taskExecutor;
+    }
+
+    /**
+     * 유저의 새로운 SSE 연결을 생성한다.
+     * - sessionId(UUID) 생성
+     * - emitter 저장
+     * - 연결 종료/오류/타임아웃 발생 시 자동 제거
+     * - 최초 연결 이벤트(connect) 전송
+     */
+    public SseEmitter createEmitter(Long userId) {
+        String sessionId = UUID.randomUUID().toString();
+        SseEmitter emitter = new SseEmitter(0L); // timeout=0 → 무제한 유지
+
+        // 유저별 세션 집합에 sessionId 추가
+        userSessions.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet()).add(sessionId);
+
+        // sessionId → emitter 매핑 저장
+        emitters.put(sessionId, emitter);
+
+        // emitter 종료/오류/타임아웃 시 정리
+        emitter.onCompletion(() -> remove(userId, sessionId));
+        emitter.onTimeout(() -> remove(userId, sessionId));
+        emitter.onError(e -> {
+            log.warn("sse emitter is on error. userId={}, sessionId={}", userId, sessionId);
+            remove(userId, sessionId);
+        });
+
+        // 최초 연결 성공 알림
+        try {
+            emitter.send(SseEmitter.event().name("connect").id(sessionId));
+        } catch (IOException e) {
+            log.warn("fail to send initial connect event. userId={}, sessionId={}", userId, sessionId);
+            remove(userId, sessionId);
+            emitter.completeWithError(e);
+        }
+
+        return emitter;
+    }
+
+    /**
+     * 비동기 작업 전용 메시지 전송 메서드입니다. <br>
+     * 메시지를 보내기 위해 외부 서비스 스레드가 진입하는 진입점입니다. 비동기을 위해, 서비스 스레드가 스레드 풀의
+     * 스레드에게 작업을 위임합니다.
+     * @param userId 보내고자 하는 목적지
+     * @param dto 메시지 내용(타입 및 데이터)
+     */
+    public void sendMessageAsync(Long userId, SseSendDto dto) {
+        taskExecutor.execute(() -> sendMessageInternal(userId, dto));
+    }
+
+    /**
+     * 동기 작업 전용 메서드 전송 메서드입니다. <br>
+     * 서비스 스레드가 전송까지 담당합니다.
+     * @param userId 보내고자 하는 목적지
+     * @param dto 메시지 내용(타입 및 데이터)
+     */
+    public void sendMessage(Long userId, SseSendDto dto) {
+        sendMessageInternal(userId, dto);
+    }
+
+    /**
+     * 내부적으로 실행되는, 유저당 발생하는 하나의 "전송 단위"입니다.
+     * 각 유저는 여러 sse 세션을 가질 수 있고, 따라서 유저 하나에게 메시지를 보낸다는 말은,
+     * 해당 sse 세션 모두에게 메시지를 보낸다는 의미입니다. 비동기 작업을 위해 하나의 작업 단위를
+     * 뺐습니다.
+     * @param userId 보내고자 하는 목적지
+     * @param dto 메시지 내용(타입 및 데이터)
+     */
+    private void sendMessageInternal(Long userId, SseSendDto dto) {
+        if (!userSessions.containsKey(userId)) return;
+
+        Set<String> ids = userSessions.get(userId);
+        if (ids.isEmpty()) {
+            userSessions.remove(userId);
+            return;
+        }
+
+        // sessionId → emitter 매핑
+        Map<String, SseEmitter> emitterMap = ids.stream().collect(Collectors.toMap(id -> id, emitters::get));
+
+        // 각 emitter로 이벤트 전송
+        for (Map.Entry<String, SseEmitter> entry : emitterMap.entrySet()) {
+            try {
+                entry.getValue()
+                        .send(SseEmitter.event()
+                                .name(dto.type())
+                                .id(entry.getKey()) // 클라이언트가 sessionId 필요할 때 사용가능
+                                .data(dto.content()));
+            } catch (IOException e) {
+                log.warn("fail to send message userId={}", userId);
+                // 실패해도 remove는 emitter 콜백(onError/onCompletion)이 자동 처리
+            }
+        }
+    }
+
+    /**
+     * SSE 연결이 종료되었을 때 세션을 정리한다.
+     * - sessionId → emitter 매핑 제거
+     * - userSessions[userId] 에서 sessionId 제거
+     * - 해당 유저의 세션이 모두 사라지면 userSessions에서도 제거
+     */
+    private void remove(Long userId, String sessionId) {
+        emitters.remove(sessionId);
+
+        Set<String> sessionIds = userSessions.get(userId);
+        if (sessionIds != null) {
+            sessionIds.remove(sessionId);
+            if (sessionIds.isEmpty()) {
+                userSessions.remove(userId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/studypals/global/sse/SseSendDto.java
+++ b/src/main/java/com/studypals/global/sse/SseSendDto.java
@@ -1,0 +1,14 @@
+package com.studypals.global.sse;
+
+/**
+ * sse 로 메시지 전송을 요청할 때 사용하는 dto 객체입니다. <br>
+ * 목적지 데이터는 포함되지 않으며 ,type 및 content 필드만 정의됩니다.
+ * <p>
+ *
+ * <p><b>외부 모듈:</b><br>
+ * SseEmitter
+ *
+ * @author jack8
+ * @since 2025-12-04
+ */
+public record SseSendDto(String type, Object content) {}

--- a/src/test/java/com/studypals/domain/chatManage/api/ChatControllerTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/api/ChatControllerTest.java
@@ -52,7 +52,7 @@ class ChatControllerTest extends WebsocketStompSupport {
 
         // then
         OutgoingMessage received = res.getMessages().get(0);
-        assertThat(received.getMessage()).isEqualTo("payload message");
+        assertThat(received.getContent()).isEqualTo("payload message");
         assertThat(received.getType()).isEqualTo(ChatType.TEXT);
         assertThat(received.getSender()).isEqualTo(userId);
     }
@@ -75,7 +75,7 @@ class ChatControllerTest extends WebsocketStompSupport {
         res.await();
 
         assertThat(res.getMessages().size()).isEqualTo(1);
-        assertThat(res.getMessages().get(0).getMessage()).isEqualTo("{\"1\":\"1111\"}");
+        assertThat(res.getMessages().get(0).getContent()).isEqualTo("{\"1\":\"1111\"}");
     }
 
     @Test

--- a/src/test/java/com/studypals/domain/chatManage/api/ChatControllerTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/api/ChatControllerTest.java
@@ -37,7 +37,7 @@ class ChatControllerTest extends WebsocketStompSupport {
         Long userId = 1L;
         int expected = 1;
         IncomingMessage message = new IncomingMessage(ChatType.TEXT, "payload message", room1);
-        OutgoingMessage outMessage = new OutgoingMessage(null, ChatType.TEXT, "payload message", userId);
+        OutgoingMessage outMessage = new OutgoingMessage(null, room1, ChatType.TEXT, "payload message", userId);
         verifyToken(userId, true);
         verifyRoom(room1, userId, true);
         verifySend();

--- a/src/test/java/com/studypals/domain/chatManage/api/SseChatRoomControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/api/SseChatRoomControllerRestDocsTest.java
@@ -1,0 +1,74 @@
+package com.studypals.domain.chatManage.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.studypals.domain.chatManage.dto.ChatRoomListRes;
+import com.studypals.domain.chatManage.service.ChatRoomService;
+import com.studypals.global.sse.SseEmitterManager;
+import com.studypals.testModules.testSupport.RestDocsSupport;
+
+/**
+ * {@link SseChatRoomController} 에 대한 rest docs test 이나, mockMvc 등이 SSE 를 테스트하는데 있어서
+ * 부적절하므로, 기본적인 연결 테스트만 수행하였습니다.
+ *
+ * @author jack8
+ * @since 2025-12-10
+ */
+@WebMvcTest(SseChatRoomController.class)
+class SseChatRoomControllerRestDocsTest extends RestDocsSupport {
+
+    @MockitoBean
+    private ChatRoomService chatRoomService;
+
+    @MockitoBean
+    private SseEmitterManager sseEmitterManager;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @WithMockUser
+    void getList_success() throws Exception {
+        Long userId = 1L;
+        SseEmitter emitter = new SseEmitter(0L);
+
+        ChatRoomListRes chatRoomListRes = new ChatRoomListRes(List.of(
+                new ChatRoomListRes.ChatRoomInfo(
+                        "0bbdf1fb-a727-4402-9fd8-c4370b7350c1",
+                        "chat-room-1-name",
+                        "image1.example.com",
+                        100,
+                        12L,
+                        "last message",
+                        "1418c88e50171000",
+                        3L),
+                new ChatRoomListRes.ChatRoomInfo(
+                        "0bbdf1fb-a727-4402-9fd8-c4370b7350c1",
+                        "chat-room-2-name",
+                        "image2.example.com",
+                        15,
+                        -1L,
+                        null,
+                        null,
+                        3L)));
+
+        given(sseEmitterManager.createEmitter(any())).willReturn(emitter);
+        given(chatRoomService.getChatRoomList(any())).willReturn(chatRoomListRes);
+
+        mockMvc.perform(get("/sse/chat/room/list").accept(MediaType.TEXT_EVENT_STREAM))
+                .andExpect(request().asyncStarted())
+                .andReturn();
+    }
+}

--- a/src/test/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryTest.java
@@ -152,7 +152,8 @@ class ChatMessageCacheRepositoryTest extends TestEnvironment {
                 })
                 .hasEntrySatisfying(roomIds.get(2), msg -> {
                     assertThat(msg.getCnt()).isEqualTo(0);
-                    assertThat(msg.getId()).isNull();
+                    assertThat(msg.getId())
+                            .isEqualTo(third.get(third.size() - 1).getId());
                 })
                 .hasEntrySatisfying(roomIds.get(3), msg -> {
                     assertThat(msg.getCnt()).isEqualTo(40);

--- a/src/test/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/dao/ChatMessageCacheRepositoryTest.java
@@ -51,9 +51,9 @@ class ChatMessageCacheRepositoryTest extends TestEnvironment {
         String chatId = Long.toHexString(snowflake.nextId());
         ChatMessage chatMessage = ChatMessage.builder()
                 .id(chatId)
-                .message("example message")
+                .content("example message")
                 .sender(1L)
-                .room(roomId)
+                .roomId(roomId)
                 .type(ChatType.TEXT)
                 .build();
 
@@ -79,8 +79,8 @@ class ChatMessageCacheRepositoryTest extends TestEnvironment {
             messages.add(ChatMessage.builder()
                     .id(Long.toHexString(snowflake.nextId()))
                     .type(ChatType.TEXT)
-                    .message("example message " + i)
-                    .room(roomId)
+                    .content("example message " + i)
+                    .roomId(roomId)
                     .sender(1L)
                     .build());
         }
@@ -211,9 +211,9 @@ class ChatMessageCacheRepositoryTest extends TestEnvironment {
         return ChatMessage.builder()
                 .id(Long.toHexString(snowflake.nextId()))
                 .type(ChatType.TEXT)
-                .message("test message")
+                .content("test message")
                 .sender(1L)
-                .room(roomId)
+                .roomId(roomId)
                 .build();
     }
 }

--- a/src/test/java/com/studypals/domain/chatManage/dao/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/dao/ChatMessageRepositoryTest.java
@@ -80,9 +80,9 @@ class ChatMessageRepositoryTest extends TestEnvironment {
         return ChatMessage.builder()
                 .id(Long.toHexString(snowflake.nextId()))
                 .type(ChatType.TEXT)
-                .room(roomId)
+                .roomId(roomId)
                 .sender(1L)
-                .message("message")
+                .content("message")
                 .build();
     }
 }

--- a/src/test/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/dao/ChatRoomMemberRepositoryTest.java
@@ -43,6 +43,8 @@ class ChatRoomMemberRepositoryTest extends DataJpaSupport {
         return em.persist(ChatRoom.builder()
                 .id(id)
                 .name("chatroom" + id)
+                .imageUrl("image.example.com")
+                .totalMember(0)
                 .createdDate(LocalDate.of(2025, 4, 1))
                 .build());
     }

--- a/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
@@ -21,16 +21,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.chatManage.api.ChatRoomController;
-import com.studypals.domain.chatManage.dto.ChatCursorRes;
-import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
-import com.studypals.domain.chatManage.dto.ChatType;
-import com.studypals.domain.chatManage.dto.OutgoingMessage;
+import com.studypals.domain.chatManage.dto.*;
 import com.studypals.domain.chatManage.entity.ChatRoomRole;
 import com.studypals.domain.chatManage.service.ChatRoomService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
 import com.studypals.global.responses.ResponseCode;
-import com.studypals.global.sse.SseEmitterManager;
 import com.studypals.testModules.testSupport.RestDocsSupport;
 
 /**
@@ -44,9 +40,6 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
 
     @MockitoBean
     private ChatRoomService chatRoomService;
-
-    @MockitoBean
-    private SseEmitterManager sseEmitterManager;
 
     @Test
     @WithMockUser
@@ -75,19 +68,19 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
                                 .build()))
                 .cursor(List.of(new ChatCursorRes(1L, "15"), new ChatCursorRes(2L, "14"), new ChatCursorRes(3L, "15")))
                 .logs(List.of(
-                        OutgoingMessage.builder()
+                        LoggingMessage.builder()
                                 .id("15")
                                 .type(ChatType.TEXT)
                                 .message("내일 10시에 회의할까요?")
                                 .sender(1L)
                                 .build(),
-                        OutgoingMessage.builder()
+                        LoggingMessage.builder()
                                 .id("14")
                                 .type(ChatType.TEXT)
                                 .message("네, 가능합니다.")
                                 .sender(2L)
                                 .build(),
-                        OutgoingMessage.builder()
+                        LoggingMessage.builder()
                                 .id("13")
                                 .type(ChatType.TEXT)
                                 .message("저도 참석할게요.")

--- a/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
@@ -48,7 +48,7 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
         String chatRoomId = "study-room-1";
 
         ChatRoomInfoRes responseData = ChatRoomInfoRes.builder()
-                .id(chatRoomId)
+                .roomId(chatRoomId)
                 .name("스터디 1반 단톡방")
                 .userInfos(List.of(
                         ChatRoomInfoRes.UserInfo.builder()
@@ -71,19 +71,19 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
                         LoggingMessage.builder()
                                 .id("15")
                                 .type(ChatType.TEXT)
-                                .message("내일 10시에 회의할까요?")
+                                .content("내일 10시에 회의할까요?")
                                 .sender(1L)
                                 .build(),
                         LoggingMessage.builder()
                                 .id("14")
                                 .type(ChatType.TEXT)
-                                .message("네, 가능합니다.")
+                                .content("네, 가능합니다.")
                                 .sender(2L)
                                 .build(),
                         LoggingMessage.builder()
                                 .id("13")
                                 .type(ChatType.TEXT)
-                                .message("저도 참석할게요.")
+                                .content("저도 참석할게요.")
                                 .sender(3L)
                                 .build()))
                 .build();
@@ -107,7 +107,7 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("status").description("응답 상태"),
                                 fieldWithPath("message").description("채팅방 ID"),
-                                fieldWithPath("data.id").description("채팅방 ID"),
+                                fieldWithPath("data.roomId").description("채팅방 ID"),
                                 fieldWithPath("data.name").description("채팅방 이름"),
                                 fieldWithPath("data.userInfos[].userId").description("유저 ID"),
                                 fieldWithPath("data.userInfos[].role").description("유저 역할 (ADMIN | MANAGER | MEMBER)"),
@@ -116,7 +116,7 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.cursor[].chatId").description("해당 유저가 마지막으로 읽은 채팅 ID"),
                                 fieldWithPath("data.logs[].id").description("채팅 ID"),
                                 fieldWithPath("data.logs[].type").description("채팅 타입 (예: TEXT)"),
-                                fieldWithPath("data.logs[].message").description("채팅 메시지 내용"),
+                                fieldWithPath("data.logs[].content").description("채팅 메시지 내용"),
                                 fieldWithPath("data.logs[].sender").description("메시지 보낸 유저 ID"))));
     }
 }

--- a/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
@@ -30,6 +30,7 @@ import com.studypals.domain.chatManage.service.ChatRoomService;
 import com.studypals.global.responses.CommonResponse;
 import com.studypals.global.responses.Response;
 import com.studypals.global.responses.ResponseCode;
+import com.studypals.global.sse.SseEmitterManager;
 import com.studypals.testModules.testSupport.RestDocsSupport;
 
 /**
@@ -43,6 +44,9 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
 
     @MockitoBean
     private ChatRoomService chatRoomService;
+
+    @MockitoBean
+    private SseEmitterManager sseEmitterManager;
 
     @Test
     @WithMockUser

--- a/src/test/java/com/studypals/domain/chatManage/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/service/ChatRoomServiceTest.java
@@ -23,6 +23,7 @@ import com.studypals.domain.chatManage.entity.*;
 import com.studypals.domain.chatManage.worker.ChatMessageReader;
 import com.studypals.domain.chatManage.worker.ChatRoomReader;
 import com.studypals.domain.memberManage.entity.Member;
+import com.studypals.domain.memberManage.worker.MemberReader;
 
 /**
  * {@link ChatRoomService} 에 대한 테스트코드
@@ -54,13 +55,17 @@ class ChatRoomServiceTest {
     @Mock
     private ChatMessageReader chatMessageReader;
 
+    @Mock
+    private MemberReader memberReader;
+
     private ChatRoomServiceImpl chatRoomService;
 
     private final ChatMessageMapper chatMessageMapper = Mappers.getMapper(ChatMessageMapper.class);
 
     @BeforeEach
     void setup() {
-        chatRoomService = new ChatRoomServiceImpl(chatRoomReader, chatRoomMapper, chatMessageMapper, chatMessageReader);
+        chatRoomService = new ChatRoomServiceImpl(
+                chatRoomReader, chatRoomMapper, chatMessageMapper, chatMessageReader, memberReader);
     }
 
     @Test

--- a/src/test/java/com/studypals/domain/chatManage/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/service/ChatRoomServiceTest.java
@@ -2,7 +2,9 @@ package com.studypals.domain.chatManage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
@@ -12,11 +14,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
+import com.studypals.domain.chatManage.dto.ChatRoomListRes;
 import com.studypals.domain.chatManage.dto.ChatType;
+import com.studypals.domain.chatManage.dto.ChatroomLatestInfo;
 import com.studypals.domain.chatManage.dto.mapper.ChatMessageMapper;
 import com.studypals.domain.chatManage.dto.mapper.ChatRoomMapper;
 import com.studypals.domain.chatManage.entity.*;
@@ -41,7 +46,10 @@ class ChatRoomServiceTest {
     private ChatRoomMapper chatRoomMapper;
 
     @Mock
-    private Member mockMember;
+    private Member mockMember1;
+
+    @Mock
+    private Member mockMember2;
 
     @Mock
     private ChatRoom mockChatRoom;
@@ -78,12 +86,15 @@ class ChatRoomServiceTest {
         given(chatRoomReader.findChatRoomMembersWithMember(mockChatRoom)).willReturn(List.of(mockCrm1, mockCrm2));
         given(mockCrm1.getLastReadMessage()).willReturn("1");
         given(mockCrm2.getLastReadMessage()).willReturn("2");
-        given(mockCrm1.getMember()).willReturn(mockMember);
+        given(mockCrm1.getMember()).willReturn(mockMember1);
+        given(mockCrm2.getMember()).willReturn(mockMember2);
+        given(mockMember1.getId()).willReturn(userId);
+        given(mockMember1.getId()).willReturn(2L);
 
         given(chatRoomMapper.toDto(any()))
                 .willReturn(new ChatRoomInfoRes.UserInfo(userId, ChatRoomRole.MEMBER, "image"));
 
-        given(mockMember.getId()).willReturn(userId);
+        given(mockMember1.getId()).willReturn(userId);
         given(chatRoomReader.getCachedCursor(chatRoomId)).willReturn(u);
         given(u.getLastMessage()).willReturn(Map.of(1L, "3"));
 
@@ -114,5 +125,63 @@ class ChatRoomServiceTest {
                 .sender(1L)
                 .message("message")
                 .build();
+    }
+
+    @Test
+    void getChatRoomList_success() {
+        // given
+        Long userId = 1L;
+
+        given(memberReader.getRef(userId)).willReturn(mockMember1);
+        given(chatRoomReader.findChatRoomMembers(mockMember1)).willReturn(List.of(mockCrm1));
+
+        given(mockCrm1.getChatRoom()).willReturn(mockChatRoom);
+        given(mockChatRoom.getId()).willReturn("chat-room");
+        // 필요하면 이름, URL, 인원 수도 스텁
+        given(mockChatRoom.getName()).willReturn("테스트 채팅방");
+        given(mockChatRoom.getImageUrl()).willReturn("https://example.com/chat-room");
+        given(mockChatRoom.getTotalMember()).willReturn(5);
+
+        // DB 기준 마지막 읽은 메시지
+        given(mockCrm1.getLastReadMessage()).willReturn("last_read_message");
+
+        // Redis 에 저장된 더 최신 커서 (키는 chatRoomId 와 같게 맞춘다)
+        given(chatRoomReader.getEachUserCursor(eq(userId), eq(List.of("chat-room"))))
+                .willReturn(Map.of("chat-room", "last_read_message_recent"));
+
+        // latest info 응답
+        given(chatMessageReader.getLatestInfo(any()))
+                .willReturn(Map.of(
+                        "chat-room",
+                        new ChatroomLatestInfo(10L, "last_read_message_recent", ChatType.TEXT, "message", 2L)));
+
+        // when
+        ChatRoomListRes result = chatRoomService.getChatRoomList(userId);
+
+        // then 1) chatMessageReader.getLatestInfo 에 넘어간 cursor 검증
+        ArgumentCaptor<Map<String, String>> cursorCaptor = ArgumentCaptor.forClass(Map.class);
+
+        then(chatMessageReader).should().getLatestInfo(cursorCaptor.capture());
+
+        Map<String, String> mergedCursor = cursorCaptor.getValue();
+        assertThat(mergedCursor).hasSize(1).containsEntry("chat-room", "last_read_message_recent");
+
+        // then 2) 반환 DTO 검증
+        assertThat(result.rooms()).hasSize(1);
+        ChatRoomListRes.ChatRoomInfo info = result.rooms().get(0);
+
+        assertThat(info.chatRoomId()).isEqualTo("chat-room");
+        assertThat(info.chatRoomName()).isEqualTo("테스트 채팅방");
+        assertThat(info.chatRoomUrl()).isEqualTo("https://example.com/chat-room");
+        assertThat(info.totalMember()).isEqualTo(5);
+        assertThat(info.unread()).isEqualTo(10L);
+        assertThat(info.lastMessage()).isEqualTo("message");
+        assertThat(info.messageId()).isEqualTo("last_read_message_recent");
+        assertThat(info.sender()).isEqualTo(2L);
+
+        // then 3) 기본 호출 관계 검증 (선택)
+        then(memberReader).should().getRef(userId);
+        then(chatRoomReader).should().findChatRoomMembers(mockMember1);
+        then(chatRoomReader).should().getEachUserCursor(userId, List.of("chat-room"));
     }
 }

--- a/src/test/java/com/studypals/domain/chatManage/service/ChatServiceTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/service/ChatServiceTest.java
@@ -9,7 +9,6 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations;
 
 import com.studypals.domain.chatManage.dto.ChatType;
 import com.studypals.domain.chatManage.dto.IncomingMessage;
-import com.studypals.domain.chatManage.dto.OutgoingMessage;
 import com.studypals.domain.chatManage.dto.mapper.ChatMessageMapper;
 
 /**
@@ -34,14 +33,9 @@ class ChatServiceTest {
         return new IncomingMessage(ChatType.TEXT, "test message", "room-id");
     }
 
-    private OutgoingMessage createOutgoing(Long userId) {
-        return new OutgoingMessage(null, ChatType.TEXT, "text message", userId);
-    }
-
     @Test
     void sendMessage_success() {
         // given
-        OutgoingMessage outgoingMessage = createOutgoing(1L);
         // given(chatMessageMapper.toOutMessage(any(), any(), any())).willReturn(outgoingMessage);
         // willDoNothing().given(template).convertAndSend(any(String.class), any(Object.class));
     }

--- a/src/test/java/com/studypals/domain/chatManage/worker/ChatMessagePipelineTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/worker/ChatMessagePipelineTest.java
@@ -45,9 +45,9 @@ class ChatMessagePipelineTest {
     ChatMessage createChat(String id, String roomId) {
         return ChatMessage.builder()
                 .id(id)
-                .room(roomId)
+                .roomId(roomId)
                 .sender(1L)
-                .message("message")
+                .content("message")
                 .type(ChatType.TEXT)
                 .build();
     }

--- a/src/test/java/com/studypals/domain/chatManage/worker/ChatMessageReaderTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/worker/ChatMessageReaderTest.java
@@ -3,12 +3,11 @@ package com.studypals.domain.chatManage.worker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.studypals.domain.chatManage.dao.ChatMessageCacheRepository;
 import com.studypals.domain.chatManage.dao.ChatMessageRepository;
 import com.studypals.domain.chatManage.dto.ChatType;
+import com.studypals.domain.chatManage.dto.ChatroomLatestInfo;
 import com.studypals.domain.chatManage.entity.ChatMessage;
 
 /**
@@ -32,10 +32,10 @@ import com.studypals.domain.chatManage.entity.ChatMessage;
 class ChatMessageReaderTest {
 
     @Mock
-    private ChatMessageRepository chatMessageRepository;
+    private ChatMessageRepository messageRepository;
 
     @Mock
-    private ChatMessageCacheRepository chatMessageCacheRepository;
+    private ChatMessageCacheRepository cacheRepository;
 
     @InjectMocks
     private ChatMessageReader chatMessageReader;
@@ -49,15 +49,15 @@ class ChatMessageReaderTest {
         }
         Collections.reverse(chatMessages);
 
-        given(chatMessageCacheRepository.fetchFromId("room", "1")).willReturn(chatMessages);
-        given(chatMessageCacheRepository.getMaxLen()).willReturn(100);
+        given(cacheRepository.fetchFromId("room", "1")).willReturn(chatMessages);
+        given(cacheRepository.getMaxLen()).willReturn(100);
 
         List<ChatMessage> response = chatMessageReader.getChatLog("room", "1");
 
         assertThat(response).hasSize(100);
 
-        verify(chatMessageRepository, never()).findRecent(any(), any());
-        verify(chatMessageCacheRepository, never()).saveAll(any());
+        verify(messageRepository, never()).findRecent(any(), any());
+        verify(cacheRepository, never()).saveAll(any());
     }
 
     @Test
@@ -73,14 +73,14 @@ class ChatMessageReaderTest {
             savedMessages.add(new ChatMessage(String.valueOf(i + 1), ChatType.TEXT, "room", 1L, "message"));
         }
 
-        given(chatMessageRepository.findRange("room", "1", "100")).willReturn(savedMessages);
-        given(chatMessageCacheRepository.fetchFromId("room", "1")).willReturn(cachedMessages);
+        given(messageRepository.findRange("room", "1", "100")).willReturn(savedMessages);
+        given(cacheRepository.fetchFromId("room", "1")).willReturn(cachedMessages);
 
         // when
         List<ChatMessage> response = chatMessageReader.getChatLog("room", "1");
 
-        verify(chatMessageRepository, never()).findRecent(any(), any());
-        verify(chatMessageCacheRepository, never()).saveAll(any());
+        verify(messageRepository, never()).findRecent(any(), any());
+        verify(cacheRepository, never()).saveAll(any());
 
         assertThat(response).hasSize(200);
     }
@@ -96,9 +96,9 @@ class ChatMessageReaderTest {
         }
         Collections.reverse(savedMessages);
 
-        given(chatMessageCacheRepository.fetchFromId("room", "1")).willReturn(cachedMessage);
-        given(chatMessageRepository.findRecent("room", "1")).willReturn(savedMessages);
-        given(chatMessageCacheRepository.getMaxLen()).willReturn(100);
+        given(cacheRepository.fetchFromId("room", "1")).willReturn(cachedMessage);
+        given(messageRepository.findRecent("room", "1")).willReturn(savedMessages);
+        given(cacheRepository.getMaxLen()).willReturn(100);
 
         // given
         List<ChatMessage> response = chatMessageReader.getChatLog("room", "1");
@@ -106,10 +106,191 @@ class ChatMessageReaderTest {
         assertThat(response).hasSize(200);
 
         ArgumentCaptor<List<ChatMessage>> captor = ArgumentCaptor.forClass(List.class);
-        verify(chatMessageCacheRepository).saveAll(captor.capture());
+        verify(cacheRepository).saveAll(captor.capture());
         List<ChatMessage> captured = captor.getValue();
         assertThat(captured).hasSize(100);
         assertThat(captured.get(0).getId()).isEqualTo("101");
         assertThat(captured.get(99).getId()).isEqualTo("200");
+    }
+
+    /**
+     * 1) 캐시 결과 cnt < 0 이고, DB 에도 메시지가 없는 경우 -> 결과에서 해당 room 제거
+     */
+    @Test
+    void getLatestInfo_cntNegative_andNoMessageInDb_thenRoomRemoved() {
+        // given
+        Map<String, String> cursor = Map.of("room1", "cursor");
+
+        Map<String, ChatroomLatestInfo> cacheResult = new HashMap<>();
+        cacheResult.put("room1", new ChatroomLatestInfo(-1L, "cursor", ChatType.TEXT, "cached", 1L));
+
+        given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
+        given(messageRepository.findTopByRoomOrderByIdDesc("room1")).willReturn(Optional.empty());
+
+        // when
+        Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
+
+        // then
+        assertThat(result).isEmpty();
+        then(cacheRepository).should().countAllToLatest(cursor);
+        then(messageRepository).should().findTopByRoomOrderByIdDesc("room1");
+        then(cacheRepository).should(never()).save(any());
+        then(cacheRepository).should(never()).saveAll(any());
+    }
+
+    /**
+     * 2) cnt < 0, DB 에 마지막 메시지가 있고, 그 ID 가 기존 ID 와 같은 경우
+     *    - cnt = 0 으로 최신 정보 반환
+     *    - cacheRepository.save(message) 한 번 호출
+     */
+    @Test
+    void getLatestInfo_cntNegative_andDbHasSameLastMessage_thenReturnLatestAndSaveOne() {
+        // given
+        Map<String, String> cursor = Map.of("room1", "cursor-id");
+
+        Map<String, ChatroomLatestInfo> cacheResult = new HashMap<>();
+        cacheResult.put("room1", new ChatroomLatestInfo(-1L, "cursor-id", ChatType.TEXT, "old", 1L));
+
+        ChatMessage latestMessage = ChatMessage.builder()
+                .id("cursor-id")
+                .type(ChatType.TEXT)
+                .room("room1")
+                .sender(10L)
+                .message("latest-message")
+                .build();
+
+        given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
+        given(messageRepository.findTopByRoomOrderByIdDesc("room1")).willReturn(Optional.of(latestMessage));
+
+        // when
+        Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
+
+        // then
+        assertThat(result).hasSize(1).containsKey("room1");
+
+        ChatroomLatestInfo info = result.get("room1");
+        assertThat(info.getCnt()).isEqualTo(0L);
+        assertThat(info.getId()).isEqualTo("cursor-id");
+        assertThat(info.getType()).isEqualTo(ChatType.TEXT);
+        assertThat(info.getMessage()).isEqualTo("latest-message");
+        assertThat(info.getSender()).isEqualTo(10L);
+
+        then(cacheRepository).should().save(latestMessage);
+        then(cacheRepository).should(never()).clear(any());
+        then(cacheRepository).should(never()).saveAll(any());
+    }
+
+    /**
+     * 3) cnt < 0, DB 에 마지막 메시지가 있고, 그 ID 가 기존 ID 와 다른 경우
+     *    - cnt = 0, 최신 메시지 기준으로 info 반환
+     *    - findTop100ByRoomOrderByIdDesc 호출
+     *    - cacheRepository.clear(room), saveAll(messages) 호출
+     */
+    @Test
+    void getLatestInfo_cntNegative_andDbHasDifferentLastMessage_thenRebuildCache() {
+        // given
+        Map<String, String> cursor = Map.of("room1", "old-id");
+
+        Map<String, ChatroomLatestInfo> cacheResult = new HashMap<>();
+        cacheResult.put("room1", new ChatroomLatestInfo(-1L, "old-id", ChatType.TEXT, "old", 1L));
+
+        ChatMessage latestMessage = ChatMessage.builder()
+                .id("new-id")
+                .type(ChatType.TEXT)
+                .room("room1")
+                .sender(20L)
+                .message("new-message")
+                .build();
+
+        // findTopByRoomOrderByIdDesc -> latestMessage
+        given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
+        given(messageRepository.findTopByRoomOrderByIdDesc("room1")).willReturn(Optional.of(latestMessage));
+
+        // findTop100ByRoomOrderByIdDesc -> 여러 메시지 (내림차순 가정)
+        ChatMessage msg3 = ChatMessage.builder()
+                .id("id3")
+                .type(ChatType.TEXT)
+                .room("room1")
+                .sender(1L)
+                .message("m3")
+                .build();
+        ChatMessage msg2 = ChatMessage.builder()
+                .id("id2")
+                .type(ChatType.TEXT)
+                .room("room1")
+                .sender(1L)
+                .message("m2")
+                .build();
+        ChatMessage msg1 = ChatMessage.builder()
+                .id("id1")
+                .type(ChatType.TEXT)
+                .room("room1")
+                .sender(1L)
+                .message("m1")
+                .build();
+
+        List<ChatMessage> messages = new ArrayList<>();
+        messages.add(msg3);
+        messages.add(msg2);
+        messages.add(msg1);
+        given(messageRepository.findTop100ByRoomOrderByIdDesc("room1")).willReturn(messages); // 내림차순
+
+        // when
+        Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
+
+        // then
+        assertThat(result).hasSize(1).containsKey("room1");
+
+        ChatroomLatestInfo info = result.get("room1");
+        assertThat(info.getCnt()).isEqualTo(0L);
+        assertThat(info.getId()).isEqualTo("new-id");
+        assertThat(info.getType()).isEqualTo(ChatType.TEXT);
+        assertThat(info.getMessage()).isEqualTo("new-message");
+        assertThat(info.getSender()).isEqualTo(20L);
+
+        // 캐시 재구성 호출 검증
+        then(cacheRepository).should().clear("room1");
+
+        ArgumentCaptor<List<ChatMessage>> msgListCaptor = ArgumentCaptor.forClass(List.class);
+        then(cacheRepository).should().saveAll(msgListCaptor.capture());
+
+        List<ChatMessage> savedList = msgListCaptor.getValue();
+        // rebuildCacheFromRecent 내부 로직에 따르면 id 오름차순으로 저장
+        assertThat(savedList).extracting(ChatMessage::getId).containsExactly("id1", "id2", "id3");
+    }
+
+    /**
+     * 4) cnt >= 0 인 경우
+     *    - cnt 를 100 으로 cap 하고 그대로 반환
+     *    - DB, 캐시 추가 접근 없음
+     */
+    @Test
+    void getLatestInfo_cntPositive_thenCapTo100AndReturn() {
+        // given
+        Map<String, String> cursor = Map.of("room1", "cursor");
+
+        Map<String, ChatroomLatestInfo> cacheResult = new HashMap<>();
+        cacheResult.put("room1", new ChatroomLatestInfo(150L, "cursor", ChatType.TEXT, "cached", 1L));
+
+        given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
+
+        // when
+        Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
+
+        // then
+        assertThat(result).hasSize(1).containsKey("room1");
+
+        ChatroomLatestInfo info = result.get("room1");
+        assertThat(info.getCnt()).isEqualTo(100L); // cap
+        assertThat(info.getId()).isEqualTo("cursor");
+        assertThat(info.getType()).isEqualTo(ChatType.TEXT);
+        assertThat(info.getMessage()).isEqualTo("cached");
+        assertThat(info.getSender()).isEqualTo(1L);
+
+        then(messageRepository).should(never()).findTopByRoomOrderByIdDesc(any());
+        then(messageRepository).should(never()).findTop100ByRoomOrderByIdDesc(any());
+        then(cacheRepository).should(never()).clear(any());
+        then(cacheRepository).should(never()).save(any());
+        then(cacheRepository).should(never()).saveAll(any());
     }
 }

--- a/src/test/java/com/studypals/domain/chatManage/worker/ChatMessageReaderTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/worker/ChatMessageReaderTest.java
@@ -125,7 +125,7 @@ class ChatMessageReaderTest {
         cacheResult.put("room1", new ChatroomLatestInfo(-1L, "cursor", ChatType.TEXT, "cached", 1L));
 
         given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
-        given(messageRepository.findTopByRoomOrderByIdDesc("room1")).willReturn(Optional.empty());
+        given(messageRepository.findTopByRoomIdOrderByIdDesc("room1")).willReturn(Optional.empty());
 
         // when
         Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
@@ -133,7 +133,7 @@ class ChatMessageReaderTest {
         // then
         assertThat(result).isEmpty();
         then(cacheRepository).should().countAllToLatest(cursor);
-        then(messageRepository).should().findTopByRoomOrderByIdDesc("room1");
+        then(messageRepository).should().findTopByRoomIdOrderByIdDesc("room1");
         then(cacheRepository).should(never()).save(any());
         then(cacheRepository).should(never()).saveAll(any());
     }
@@ -154,13 +154,13 @@ class ChatMessageReaderTest {
         ChatMessage latestMessage = ChatMessage.builder()
                 .id("cursor-id")
                 .type(ChatType.TEXT)
-                .room("room1")
+                .roomId("room1")
                 .sender(10L)
-                .message("latest-message")
+                .content("latest-message")
                 .build();
 
         given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
-        given(messageRepository.findTopByRoomOrderByIdDesc("room1")).willReturn(Optional.of(latestMessage));
+        given(messageRepository.findTopByRoomIdOrderByIdDesc("room1")).willReturn(Optional.of(latestMessage));
 
         // when
         Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
@@ -172,7 +172,7 @@ class ChatMessageReaderTest {
         assertThat(info.getCnt()).isEqualTo(0L);
         assertThat(info.getId()).isEqualTo("cursor-id");
         assertThat(info.getType()).isEqualTo(ChatType.TEXT);
-        assertThat(info.getMessage()).isEqualTo("latest-message");
+        assertThat(info.getContent()).isEqualTo("latest-message");
         assertThat(info.getSender()).isEqualTo(10L);
 
         then(cacheRepository).should().save(latestMessage);
@@ -197,43 +197,43 @@ class ChatMessageReaderTest {
         ChatMessage latestMessage = ChatMessage.builder()
                 .id("new-id")
                 .type(ChatType.TEXT)
-                .room("room1")
+                .roomId("room1")
                 .sender(20L)
-                .message("new-message")
+                .content("new-message")
                 .build();
 
         // findTopByRoomOrderByIdDesc -> latestMessage
         given(cacheRepository.countAllToLatest(cursor)).willReturn(cacheResult);
-        given(messageRepository.findTopByRoomOrderByIdDesc("room1")).willReturn(Optional.of(latestMessage));
+        given(messageRepository.findTopByRoomIdOrderByIdDesc("room1")).willReturn(Optional.of(latestMessage));
 
         // findTop100ByRoomOrderByIdDesc -> 여러 메시지 (내림차순 가정)
         ChatMessage msg3 = ChatMessage.builder()
                 .id("id3")
                 .type(ChatType.TEXT)
-                .room("room1")
+                .roomId("room1")
                 .sender(1L)
-                .message("m3")
+                .content("m3")
                 .build();
         ChatMessage msg2 = ChatMessage.builder()
                 .id("id2")
                 .type(ChatType.TEXT)
-                .room("room1")
+                .roomId("room1")
                 .sender(1L)
-                .message("m2")
+                .content("m2")
                 .build();
         ChatMessage msg1 = ChatMessage.builder()
                 .id("id1")
                 .type(ChatType.TEXT)
-                .room("room1")
+                .roomId("room1")
                 .sender(1L)
-                .message("m1")
+                .content("m1")
                 .build();
 
         List<ChatMessage> messages = new ArrayList<>();
         messages.add(msg3);
         messages.add(msg2);
         messages.add(msg1);
-        given(messageRepository.findTop100ByRoomOrderByIdDesc("room1")).willReturn(messages); // 내림차순
+        given(messageRepository.findTop100ByRoomIdOrderByIdDesc("room1")).willReturn(messages); // 내림차순
 
         // when
         Map<String, ChatroomLatestInfo> result = chatMessageReader.getLatestInfo(cursor);
@@ -245,7 +245,7 @@ class ChatMessageReaderTest {
         assertThat(info.getCnt()).isEqualTo(0L);
         assertThat(info.getId()).isEqualTo("new-id");
         assertThat(info.getType()).isEqualTo(ChatType.TEXT);
-        assertThat(info.getMessage()).isEqualTo("new-message");
+        assertThat(info.getContent()).isEqualTo("new-message");
         assertThat(info.getSender()).isEqualTo(20L);
 
         // 캐시 재구성 호출 검증
@@ -284,11 +284,11 @@ class ChatMessageReaderTest {
         assertThat(info.getCnt()).isEqualTo(100L); // cap
         assertThat(info.getId()).isEqualTo("cursor");
         assertThat(info.getType()).isEqualTo(ChatType.TEXT);
-        assertThat(info.getMessage()).isEqualTo("cached");
+        assertThat(info.getContent()).isEqualTo("cached");
         assertThat(info.getSender()).isEqualTo(1L);
 
-        then(messageRepository).should(never()).findTopByRoomOrderByIdDesc(any());
-        then(messageRepository).should(never()).findTop100ByRoomOrderByIdDesc(any());
+        then(messageRepository).should(never()).findTopByRoomIdOrderByIdDesc(any());
+        then(messageRepository).should(never()).findTop100ByRoomIdOrderByIdDesc(any());
         then(cacheRepository).should(never()).clear(any());
         then(cacheRepository).should(never()).save(any());
         then(cacheRepository).should(never()).saveAll(any());

--- a/src/test/java/com/studypals/domain/chatManage/worker/ChatRoomReaderTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/worker/ChatRoomReaderTest.java
@@ -1,0 +1,66 @@
+package com.studypals.domain.chatManage.worker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.util.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.studypals.domain.chatManage.dao.ChatRoomMemberRepository;
+import com.studypals.domain.chatManage.dao.ChatRoomRepository;
+import com.studypals.domain.chatManage.dao.UserLastReadMessageRepository;
+
+/**
+ *
+ *
+ * @author jack8
+ * @since 2025-12-10
+ */
+@ExtendWith(MockitoExtension.class)
+class ChatRoomReaderTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Mock
+    private UserLastReadMessageRepository userLastReadMessageRepository;
+
+    @InjectMocks
+    private ChatRoomReader chatRoomReader;
+
+    @Test
+    void getEachUserCursor_success() {
+        // given
+        Long userId = 1L;
+        List<String> roomIds = new ArrayList<>();
+        Map<String, Map<String, String>> rawResult = new HashMap<>();
+
+        for (int i = 0; i < 5; i++) {
+            roomIds.add(UUID.randomUUID().toString());
+            rawResult.put(roomIds.get(i), Map.of(userId.toString(), "aaaaa" + i));
+        }
+
+        given(userLastReadMessageRepository.findHashFieldsById(any())).willReturn(rawResult);
+
+        // when
+        Map<String, String> result = chatRoomReader.getEachUserCursor(userId, roomIds);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .hasEntrySatisfying(roomIds.get(0), v -> assertThat(v).isEqualTo("aaaaa" + 0))
+                .hasEntrySatisfying(roomIds.get(1), v -> assertThat(v).isEqualTo("aaaaa" + 1))
+                .hasEntrySatisfying(roomIds.get(2), v -> assertThat(v).isEqualTo("aaaaa" + 2))
+                .hasEntrySatisfying(roomIds.get(3), v -> assertThat(v).isEqualTo("aaaaa" + 3))
+                .hasEntrySatisfying(roomIds.get(4), v -> assertThat(v).isEqualTo("aaaaa" + 4));
+    }
+}

--- a/src/test/java/com/studypals/domain/chatManage/worker/ChatRoomWriterTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/worker/ChatRoomWriterTest.java
@@ -52,7 +52,7 @@ class ChatRoomWriterTest {
     @Test
     void create_success() {
         // given
-        CreateChatRoomDto dto = new CreateChatRoomDto("chatRoom");
+        CreateChatRoomDto dto = new CreateChatRoomDto("chatRoom", "example.com");
         given(chatRoomRepository.save(any())).willReturn(mockChatRoom);
 
         // when
@@ -73,6 +73,7 @@ class ChatRoomWriterTest {
         given(chatRoomMemberRepository.findByChatRoomIdAndMemberId(chatRoomId, userId))
                 .willReturn(Optional.of(mockCrm));
         given(mockCrm.isAdmin()).willReturn(true);
+        given(chatRoomRepository.decreaseChatMember(chatRoomId)).willReturn(1);
 
         // when & then
         assertThatThrownBy(() -> chatRoomWriter.leave(mockChatRoom, mockMember))

--- a/src/test/java/com/studypals/domain/chatManage/worker/ReactiveChatSaveWorkerTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/worker/ReactiveChatSaveWorkerTest.java
@@ -48,16 +48,16 @@ class ReactiveChatSaveWorkerTest {
         // given
         ChatMessage msg1 = ChatMessage.builder()
                 .id("1-0")
-                .room("room1")
+                .roomId("room1")
                 .sender(1L)
-                .message("hello")
+                .content("hello")
                 .build();
 
         ChatMessage msg2 = ChatMessage.builder()
                 .id("2-0")
-                .room("room1")
+                .roomId("room1")
                 .sender(2L)
-                .message("world")
+                .content("world")
                 .build();
 
         List<ChatMessage> input = List.of(msg1, msg2);

--- a/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
@@ -24,11 +24,13 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
     private GroupMemberRepository groupMemberRepository;
 
     private ChatRoom insertChatRoom(String id) {
-        return em.persist(ChatRoom.builder().id(id).name("name" + id).build());
+        return em.persist(
+                ChatRoom.builder().id(id).name("name" + id).totalMember(1).build());
     }
 
     private Group insertGroup(ChatRoom chatRoom) {
         return em.persist(Group.builder()
+                .totalMember(1)
                 .name("group")
                 .tag("tag")
                 .totalMember(2)

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
@@ -74,7 +74,7 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
     void createGroup_success() throws Exception {
 
         // given
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(groupService.createGroup(any(), any())).willReturn(1L);
 
@@ -90,6 +90,9 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                         httpResponse(),
                         requestFields(
                                 fieldWithPath("name").description("그룹명").attributes(constraints("not null")),
+                                fieldWithPath("imageUrl")
+                                        .description("그룹 이미지 주소")
+                                        .attributes(constraints("nullable - null 인 경우 클라이언트 자체적인 이미지 사용")),
                                 fieldWithPath("tag").description("그룹 태그").attributes(constraints("not null")),
                                 fieldWithPath("maxMember")
                                         .description("그룹 최대 인원수 / Default 100")

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
@@ -90,7 +90,7 @@ public class GroupServiceTest {
     void createGroup_success() {
         // given
         Long userId = 1L;
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(memberReader.getRef(userId)).willReturn(mockMember);
         given(groupWriter.create(req)).willReturn(mockGroup);
@@ -109,7 +109,7 @@ public class GroupServiceTest {
         // given
         Long userId = 1L;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_CREATE_FAIL;
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(groupWriter.create(req)).willThrow(new GroupException(errorCode));
 
@@ -125,7 +125,7 @@ public class GroupServiceTest {
         // given
         Long userId = 1L;
         GroupErrorCode errorCode = GroupErrorCode.GROUP_MEMBER_CREATE_FAIL;
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(memberReader.getRef(userId)).willReturn(mockMember);
         given(groupWriter.create(req)).willReturn(mockGroup);

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupWriterTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupWriterTest.java
@@ -48,7 +48,7 @@ public class GroupWriterTest {
     @Test
     void create_success() {
         // given
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(groupMapper.toEntity(req)).willReturn(mockGroup);
         given(groupTagRepository.existsById(req.tag())).willReturn(true);
@@ -64,7 +64,7 @@ public class GroupWriterTest {
     void create_fail_tagNotFound() {
         // given
         GroupErrorCode errorCode = GroupErrorCode.GROUP_CREATE_FAIL;
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(groupMapper.toEntity(req)).willReturn(mockGroup);
         given(groupTagRepository.existsById(req.tag())).willReturn(false);
@@ -80,7 +80,7 @@ public class GroupWriterTest {
     void create_fail_whileSave() {
         // given
         GroupErrorCode errorCode = GroupErrorCode.GROUP_CREATE_FAIL;
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         given(groupMapper.toEntity(req)).willReturn(mockGroup);
         given(groupTagRepository.existsById(req.tag())).willReturn(true);

--- a/src/test/java/com/studypals/domain/studyManage/restDocsTest/StudySessionControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/restDocsTest/StudySessionControllerRestDocsTest.java
@@ -104,11 +104,11 @@ class StudySessionControllerRestDocsTest extends RestDocsSupport {
                 .andDo(restDocs.document(
                         httpRequest(),
                         httpResponse(),
-                        requestFields(fieldWithPath("endTime").description("공부 종료 시간 - HH:mm 형식")),
+                        requestFields(fieldWithPath("endTime").description("공부 종료 시간 - HH:mm:ss 형식")),
                         responseFields(
                                 fieldWithPath("code").description("U03-03 고정"),
                                 fieldWithPath("status").description("응답 상태 (예: success 또는 fail)"),
                                 fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("총 공부 시간(분)"))));
+                                fieldWithPath("data").description("총 공부 시간(초)"))));
     }
 }

--- a/src/test/java/com/studypals/integrationTest/ChatRoomIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/ChatRoomIntegrationTest.java
@@ -16,10 +16,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.chatManage.api.ChatRoomController;
-import com.studypals.domain.chatManage.dto.ChatCursorRes;
-import com.studypals.domain.chatManage.dto.ChatRoomInfoRes;
-import com.studypals.domain.chatManage.dto.ChatType;
-import com.studypals.domain.chatManage.dto.OutgoingMessage;
+import com.studypals.domain.chatManage.dto.*;
 import com.studypals.domain.chatManage.entity.ChatMessage;
 import com.studypals.domain.chatManage.entity.ChatRoomRole;
 import com.studypals.global.responses.CommonResponse;
@@ -92,9 +89,9 @@ public class ChatRoomIntegrationTest extends IntegrationSupport {
                 new ChatCursorRes(user3.getUserId(), "15"));
 
         // logs: id 15 ~ 1, 모두 TEXT / "message" / sender = user1
-        List<OutgoingMessage> logs = new ArrayList<>();
+        List<LoggingMessage> logs = new ArrayList<>();
         for (int i = 15; i >= 1; i--) {
-            logs.add(OutgoingMessage.builder()
+            logs.add(LoggingMessage.builder()
                     .id(String.valueOf(i))
                     .type(ChatType.TEXT)
                     .message("message")

--- a/src/test/java/com/studypals/integrationTest/ChatRoomIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/ChatRoomIntegrationTest.java
@@ -94,13 +94,13 @@ public class ChatRoomIntegrationTest extends IntegrationSupport {
             logs.add(LoggingMessage.builder()
                     .id(String.valueOf(i))
                     .type(ChatType.TEXT)
-                    .message("message")
+                    .content("message")
                     .sender(user1.getUserId())
                     .build());
         }
 
         ChatRoomInfoRes responseData = ChatRoomInfoRes.builder()
-                .id(chatRoomId)
+                .roomId(chatRoomId)
                 .name("chatRoom")
                 .userInfos(List.of(
                         ChatRoomInfoRes.UserInfo.builder()

--- a/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
@@ -12,6 +12,7 @@ import java.sql.Statement;
 import java.time.LocalDate;
 import java.util.Objects;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import com.studypals.global.responses.ResponseCode;
  */
 @ActiveProfiles("test")
 @DisplayName("API TEST / 그룹 가입 관리 통합 테스트")
+@Disabled // 추후 전반적인 리펙토링 예정
 public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
     @Autowired
     private GroupEntryCodeRedisRepository entryCodeRedisRepository;
@@ -87,7 +89,8 @@ public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
     @DisplayName("POST /groups/join")
     void joinGroup_success() throws Exception {
         // given
-        CreateGroupVar group = createGroup(createUser().getUserId(), "group", "tag", false);
+        CreateUserVar initUser = createUser();
+        CreateGroupVar group = createGroup(initUser.getUserId(), "group", "tag", false);
         CreateUserVar user = createUser("member_username", "member");
         GroupEntryCode groupEntryCode = new GroupEntryCode("1A2B3C", group.groupId());
         GroupEntryReq req = new GroupEntryReq(group.groupId(), groupEntryCode.getCode());

--- a/src/test/java/com/studypals/integrationTest/GroupIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupIntegrationTest.java
@@ -56,7 +56,7 @@ public class GroupIntegrationTest extends AbstractGroupIntegrationTest {
         // given
         CreateUserVar user = createUser();
         createGroupTag("group tag");
-        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false);
+        CreateGroupReq req = new CreateGroupReq("group name", "group tag", 10, false, false, "image.example.com");
 
         // when
         ResultActions result = mockMvc.perform(post("/groups")


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

시작하기 앞서, 실제 리뷰가 필요한 부분은 약 880줄 정도 임을 알려드립니다. 나머지는 테스트 , 주석 등입니다.
<!-- Auto close 할 이슈 번호 -->
- close #69

## ✨ 구현 기능 명세
 
### 채팅방 리스트 SSE 로직

SSE를 사용한 채팅방 리스트 반환 API를 구성하였습니다. 

- 최초 1회, 모든 채팅방의 데이터가 리스트 형식으로 전송됩니다. 이때 포함되는 각 데이터는 다음과 같습니다. 해당 데이터는 `ChatRoomListRes` DTO 에 정의가 되어 있습니다.
    - type : "init-message"
    - 채팅방 아이디 (`chatRoomId`)
    - 채팅방 이름 (`chatRoomName`)
    - 채팅방 이미지 주소 (`chatRoomUrl`)
    - 채팅방 총 인원 수 (`totalMember`)
    - 안 읽은 메시지 개수 (`unread`)
    - 마지막 메시지 내용(`lastMessage`)
    - 마지막 메시지 아이디(`messageId`)
    - 마지막 메시지 글쓴이(`sender`)

- 새로운 메시지가 발행될 때마다, SSE에 연결된 사용자에게 메시지를 전송합니다. 이때 포함되는 각 데이터는 `OutgoingMesssage` 와 동일합니다.
    - type : "new-message"
    - 채팅 아이디 (`id`)
    - 채팅 타입(`TEXT`)
    - 메시지 내용(`message`)
    - 메시지 글쓴이(`sender`)

---

### SSE 접속 중 새로운 메시지 생성 시 SSE 로 전송
사용자가 SSE 에 접속 중, 자신이 속한 채팅방에 새로운 메시지가 발행되면 해당 정보를 전송합니다. 이는 `OutgoingMessage` 와 동일한 타입입니다. SseEmitterManager 에서 사용자 아이디에 따른 연결 세션 객체인 `SseEmitter` 를 concurrentHashMap 으로 관리하며, 이를 위해 사용자가 속한 채팅방에 대한 캐시를 적용하였습니다. 이는 어노테이션에 대해 관리되는 spring-cache 의존성에 의한 것입니다.

---

### SSE manager 정의

보다 쉬운 SSE 전송 로직 관리를 위해 SseEmitter 및, 예외 처리 로직을 정의하였습니다.

- SSE 연결용 `SseEmitter` 생성 및 `connect` 프레임 추가
`SseEmitterManager#createEmitter` 를 통해 새로운 `SseEmitter` 를 생성하고, 유저 및 해당 연결 세션에 따라 인메모리에 저장합니다. 따라서 유저는 여러 클라이언트에서 동시에 SSE 연결을 할 수 있고 서버는 같은 유저의 중복된 연결에 동시에 메시지를 보낼 수 있습니다.

- 메시지 동기 전송 및 비동기 전송 로직 추가
`SseEmitterManager#sendMessage` 및 `SseEmitterManager#sendMessageAsync` 는 각각 SSE 메시지를 동기/비동기로 전송합니다. 파라미터로 유저 아이디와, SSE 메시지 형식인 `SseSendDto` 를 받으며, 내부적으로 특정 객체를 집어넣어 직렬화를 수행할 수 있습니다.

- 연결 끊김, 오류 처리
연결이 끊기거나, 메시지를 전송 중 서버 오류 등이 발생하는 경우, 경우에 따라 연결을 끊거나, 클라이언트로 오류 메시지를 전송합니다. 이는 `SseExceptionHandler` 를 통해 이뤄집니다.
연결 자체의 오류 (`IOException`) 등은 클라이언트와의 연결 종료 등이므로 세션을 삭제하고, 서버 내부 오류는 오류 메시지를 클라이언트로 전송합니다.

### 채팅방 및 그룹에 일부 칼럼 추가
채팅방 및 그룹 이미지와, 채팅방의 현재 참여 인원 수 등을 표시하기 위한 칼럼을 추가하였습니다. 유저가 가입할 때마다 해당 필드인 `total_member` 의 증감 연산을 원자적으로 수행하여 동시성 문제를 해결하였으며 updated 된 레코드 수를 기반으로 추가/삭제 실패 여부를 판단하도록 하였습니다. 

채팅방 정보를 가져올 때, 총 참여 인원 수를 가져와야 합니다. 이때, 모든 요청마다 `chat_room_member` 를 `count()` 하기엔 오버헤드가 크다고 판단하여 정합성이 떨어질 수 있더라도 개별적인 필드를 두었습니다.

---

### 채팅 로깅 로직 정리
여러 채팅방에 대해, 가장 최신의 메시지 데이터를 받아오는 기능을 구현할 때, 채팅방 캐싱 전략을 수정하였습니다.
기존의 채팅 기록 캐싱은 다음과 같이 이루어졌습니다.
- redis 에서 채팅 기록을 가져옵니다.
- 요청 데이터가 redis 에 저장된 데이터보다 이전의 기록을 요구한다면, mongoDB 에서 데이터를 조회하여 반환합니다.
- 채팅 저장 시, redis 와 mongoDB 에 동시에 저장합니다.

이는 다음과 같은 문제가 있습니다.

#### 상황 1 : 매 요청마다 mongoDB 를 타야 되는 경우

1. 각 채팅방의 가장 최신 메시지 데이터를 가져와야 되는 경우, 해당 캐시에서 값을 가져오게 됩니다.
2. 만약 채팅방이 활성화되지 않아(가장 마지막으로 조회, 메시지 발행한게 오래 전이라면) 캐시에서 지워진 상태입니다.
3. 이때 각 채팅방의 "가장 마지막 메시지 데이터"를 가져오기 위해선 mongoDB 를 여러 번 타야 합니다.

#### 상황 2 : 캐시에서 사라진 로그를 가져오기 위해서 항상 mongoDB 를 타야 되는 경우

1. 오래되어 사라진 채팅 로그 캐시에 대해, 그 데이터를 가져오는 경우, 남아있는 데이터가 없기 때문에 모든 항목을 mongoDB 에서 가져옵니다.
2. 본래라면 요청이 발생하는 순간, 해당 채팅방이 활성화되었다고 판단하여 캐시를 재구성하여 올리는게 맞습니다. 그러나 기존에는 단순히 조회 후 반환만 수행하므로 새로운 캐시를 재구성하여 저장하지 않습니다.

해당 경우를 해결하기 위해 다음과 같은 캐싱 - 저장 로직을 추가하였습니다.

#### 캐시 재구성 로직 추가

캐시에서 삭제된 데이터(캐시에는 없으나, mongoDB 에는 존재하는 데이터) 가 존재하고, 캐시된 데이터가 MAX_LEN 개 이하인 경우 -> 캐시 데이터 + 영속화 데이터(mongoDB) 를 합쳐 캐시를 재구성합니다.

캐시에 MAX_LEN 개 이하의 데이터가 들어있으며, 그럼에도 MongoDB 에서 캐시에 존재하지 않은 데이터를 검색했을 때 무언가 존재한다면 이는 기존 로그 캐시 중, 시간이 오래되어 사라진 데이터가 존재한다는 의미이므로 재구성합니다.

#### 최신 메시지 조회 시 죽어있는 채팅방에 대해 단 1개의 데이터만 캐싱
해당 기능은, 죽어있는 채팅방의 채팅 로그를 굳이 100개 씩 캐싱할 필요가 있을까 라는 의문에서 출발하였습니다. 사용자에게 필요한 정보는, 채팅방 리스트에 띄울 단 1개의 데이터인데 필요 없는 99개의 데이터를 가지고 있을 필요가 없다고 판단하였습니다.

따라서 채팅방 리스트를 구성하기 위해 각 채팅방의 가장 마지막 메시지 데이터를 가져오는 경우, 만약 이미 캐시된 내역이 있으면(최근까지 활성화된 채팅방) 해당 값을 그대로 가져옵니다.

그러나 캐시된 내역이 없으면(이미 죽은 채팅방이되어 캐시된 데이터가 사라진 상태), mongoDB 에서 단 1개의 데이터만 가져와 사용자의 요청 채팅 아이디와 비교하여, 동일하면 1개만 저장, 아닌 경우 캐시를 전부 재구성합니다. 

- 단 1개만 가져오는 경우 : `/sse/chat/room/list` 를 통해 채팅방 리스트를 가져오는 사용자가, "가장 마지막으로 읽은 메시지"와, 실제 채팅방의 가장 마지막 메시지와 동일한 경우
> 즉, 사용자의 unread count 가 0 인 경우
<img width="1137" height="121" alt="image" src="https://github.com/user-attachments/assets/ffc51b77-54bb-48ea-b21e-74200334df63" />
Redis 에는 가장 최신의 메시지만 저장되며, 추후 사용자가 동일한 요청을 보내면 데이터가 정상적으로 들어온다(가장 마지막 데이터만 조회하면 되므로)

- 데이터를 전부 가져와 캐시를 재구성 하는 경우
사용자가 마지막으로 읽은 메시지와, 영속화된 데이터 상 가장 마지막 메시지가 서로 다른 경우는 어쩌피 "읽지 않은 메시지 개수"를 세야 하므로 캐시를 채움. 이때, 100개를 채워 넣어 캐시를 재구성

또한, 로그 자체를 요구하는 경우 또한 영속화된 데이터를 전부 가져와 캐시를 재구성

> 따라서, 1개의 데이터만 캐시에 저장하는 경우는, (1) 최근에 채팅 로그를 요청한 적이 없으며, (2) 채팅방 리스트를 조회하는 유저가 해당 채팅방의 가장 최근 메시지를 읽은 상태인 경우, 에 해당 됩니다.

---




## ✅ PR Point

### `SseEmitterManager`
Sse 연결 세션을 담당하는 `SseEmitter` 를 관리하는 객체입니다. 각 유저 당 세션을 유지, 관리하기 위해 다음 두 map 을 사용합니다.

```java
    /** 유저ID → 세션ID 집합 */
    private final ConcurrentMap<Long, Set<String>> userSessions = new ConcurrentHashMap<>();

    /** 세션ID → SseEmitter */
    private final ConcurrentMap<String, SseEmitter> emitters = new ConcurrentHashMap<>();
```
`userSession` 은 사용자에 대해, 임의로 부여한 UUID , 즉 세션 아이디를 매핑합니다.  다 클라이언트 환경 상 하나의 유저가 여러 SSE 접속을 이룰 수 있고 그에 따라 한 유저당 여러 세션을 가질 수 있습니다. 다만 `Map<Long, Set<SseEmitter>>` 를 하지 않고 이를 분리한 이유는 세션 종료 시 sessionId 로 관리하기 위함입니다. 
SseEmitter 를 Set 으로 묶어 사용자 아이디로 바인딩하는 경우
- SseEmitter 간의 동등성 비교가 불가하다. ( 종료, 에러 시 래핑된 객체가 올 수 있음)
- 유저당 세션 / 각 세션의 수명 으로의 책임 분리가 불가하다.

등의 문제가 생길 수 있습니다. 

또한, 최초 연결 시 진입 메서드`createEmitter` 의 경우, 연결 직후 `connect` type 의 메시지를 보내어 클라이언트와 연결을 검증하도록 합니다. 

#### sendMessageAsync

해당 메서드를 설명하기 앞서,  SseEmitterManager 는 taskExecutor 를 가져와 사용합니다. 이는 `SSEConfig` 에서 등록한 스레드 풀로, SSE 의 연결을 관리하는 스레드에 대한 풀이며 마찬가지로 비동기 전송 로직에서도 해당 스레드 풀을 재사용합니다. 

메시지 전송은 정의된 DTO 를 통해 가능하며, type 과 body 로 이루어져 있습니다. type 은 해당 sse 메시지의 용도 등에 대한 정의입니다.

#### remove
연결이 끊기거나, 명시적으로 종료하거나, 내부 서버 오류 등으로 해당 SSE 연결 세션을 종료해야 할 때 사용합니다. cretaeEmitter 에서 정의한 `onComplete` 등에서도 해당 메서드를 사용합니다.

기본적으로 map 에서 세션을 삭제하며 이후 메시지를 보낼 때 해당 emitter 를 사용하지 않도록 하여 자연스럽게 종료 되도록 합니다.

---

### 채팅 캐시 전략
해당 부분은 문서화를 하였습니다. 문서를 참고해 주세요.
[채팅 로그 로직](https://github.com/study-pals/backend/wiki/%EC%B1%84%ED%8C%85-%EB%A1%9C%EA%B7%B8-%EC%BA%90%EC%8B%B1-%EC%A0%84%EB%9E%B5)




