### PR TITLE
[#129][REFACTOR] 회원가입 API 분리

### DIFF
--- a/src/asciidoc/api/member.adoc
+++ b/src/asciidoc/api/member.adoc
@@ -39,15 +39,15 @@
 
 '''
 
-include::{snippets}/auth-controller-rest-docs-test/register_success/request-fields.adoc[]
-include::{snippets}/auth-controller-rest-docs-test/register_success/http-request.adoc[]
+include::{snippets}/member-controller-rest-docs-test/register_success/request-fields.adoc[]
+include::{snippets}/member-controller-rest-docs-test/register_success/http-request.adoc[]
 
 *RESPONSE* +
 
 '''
 
-include::{snippets}/auth-controller-rest-docs-test/register_success/response-fields.adoc[]
-include::{snippets}/auth-controller-rest-docs-test/register_success/http-response.adoc[]
+include::{snippets}/member-controller-rest-docs-test/register_success/response-fields.adoc[]
+include::{snippets}/member-controller-rest-docs-test/register_success/http-response.adoc[]
 
 ==== 2. 로그인
 *Description* +
@@ -98,6 +98,52 @@ include::{snippets}/auth-controller-rest-docs-test/refresh-token_success/request
 include::{snippets}/auth-controller-rest-docs-test/refresh-token_success/response-fields.adoc[]
 include::{snippets}/auth-controller-rest-docs-test/refresh-token_success/http-response.adoc[]
 
+==== 4. 프로필 정보 입력/수정
+*Description* +
+
+'''
+
+회원가입 시 필요한 부가 정보(프로필 정보)를 삽입/수정합니다. 최초 회원가입 직후 빈 프로필 데이터 삽입 및, 추후
+새로운 데이터를 입력해야되는 경우 사용합니다.
+
+[NOTE]
+null 값을 입력하면, 갱신이 안되는 것이 아닌 실제로 null 값이 들어가게 됩니다. 따라서, 기존 데이터를 유지하고 싶은 경우 기존 데이터를
+그대로 넣어줘야 합니다.
+
+*REQUEST* +
+
+'''
+
+include::{snippets}/member-controller-rest-docs-test/update-profile_success/request-fields.adoc[]
+include::{snippets}/member-controller-rest-docs-test/update-profile_success/http-request.adoc[]
+
+*RESPONSE* +
+
+'''
+
+include::{snippets}/member-controller-rest-docs-test/update-profile_success/response-fields.adoc[]
+include::{snippets}/member-controller-rest-docs-test/update-profile_success/http-response.adoc[]
+
+==== 5. 본인 프로필 조회
+*Description* +
+
+'''
+
+사용자 본인의 프로필을 조회합니다.
+
+*REQUEST* +
+
+'''
+
+include::{snippets}/member-controller-rest-docs-test/get-profile_success/http-request.adoc[]
+
+*RESPONSE* +
+
+'''
+
+include::{snippets}/member-controller-rest-docs-test/get-profile_success/response-fields.adoc[]
+include::{snippets}/member-controller-rest-docs-test/get-profile_success/http-response.adoc[]
+
 
 == ⛔ 예외 출력
 
@@ -116,7 +162,7 @@ include::{snippets}/auth-controller-rest-docs-test/refresh-token_success/http-re
 
 '''
 
-include::{snippets}/auth-controller-rest-docs-test/register_fail_duplicate_user/http-response.adoc[]
+include::{snippets}/member-controller-rest-docs-test/register_fail_duplicate_user/http-response.adoc[]
 
 ==== 2. 로그인 시
 

--- a/src/asciidoc/api/member.adoc
+++ b/src/asciidoc/api/member.adoc
@@ -129,7 +129,11 @@ include::{snippets}/member-controller-rest-docs-test/update-profile_success/http
 
 '''
 
-사용자 본인의 프로필을 조회합니다.
+사용자 본인의 프로필을 조회합니다. 일부 값에 null 값이 올 수 있습니다. birthday, position, imageUrl 등은 사용자의 선택에 따라
+입력되지 않을 수 있고, null 값이 올 수 있습니다. 따라서 이에 대한 적절한 가공이 필요합니다.
+
+imageUrl 같은 경우는 null 값이 오게 되면, 클라이언트에서 자체적으로 보유 중인 기본 이미지를 사용하는 것을 권장 드립니다. 이는 프로필
+조회 뿐만 아니라 추후 다른 사용자의 이미지 또한 null 인 경우 기본 이미지를 사용하도록 해야 합니다.
 
 *REQUEST* +
 

--- a/src/main/java/com/studypals/domain/memberManage/api/AuthController.java
+++ b/src/main/java/com/studypals/domain/memberManage/api/AuthController.java
@@ -20,10 +20,9 @@ import com.studypals.global.responses.ResponseCode;
 import com.studypals.global.security.jwt.JwtToken;
 
 /**
- * 회원가입/로그인 및 기타 권한 , 인증 등에 대한 컨트롤러입니다. 담당하는 엔드포인트는 다음과 같습니다.
+ * 로그인 및 기타 권한 , 인증 등에 대한 컨트롤러입니다. 담당하는 엔드포인트는 다음과 같습니다.
  *
  * <pre>
- *     - POST /register : 회원가입({@link CreateMemberReq})
  *     - POST /sign-in : 로그인({@link SignInReq})
  *     - POST /refresh : 토큰 재발급({@link TokenReissueReq}
  * </pre>
@@ -38,15 +37,6 @@ public class AuthController {
     private final MemberService memberService;
     private final SignInService signInService;
     private final TokenService tokenService;
-
-    @PostMapping("/register")
-    public ResponseEntity<Response<Long>> register(@Valid @RequestBody CreateMemberReq req) {
-        Long id = memberService.createMember(req);
-        Response<Long> response =
-                CommonResponse.success(ResponseCode.USER_CREATE, id, "success createWithCategory user");
-
-        return ResponseEntity.ok(response);
-    }
 
     @PostMapping("/sign-in")
     public ResponseEntity<Response<JwtToken>> signIn(@Valid @RequestBody SignInReq req) {

--- a/src/main/java/com/studypals/domain/memberManage/api/MemberController.java
+++ b/src/main/java/com/studypals/domain/memberManage/api/MemberController.java
@@ -1,0 +1,56 @@
+package com.studypals.domain.memberManage.api;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+import com.studypals.domain.memberManage.dto.*;
+import com.studypals.domain.memberManage.service.MemberService;
+import com.studypals.global.responses.CommonResponse;
+import com.studypals.global.responses.Response;
+import com.studypals.global.responses.ResponseCode;
+
+/**
+ * 회원가입/프로필 관련 API 입니다.
+ *
+ * <pre>
+ *     - POST /register : 회원가입({@link CreateMemberReq})
+ *     - GET /profile : 프로필 조회
+ *     - PUT /profile : 프로필 수정 ({@link UpdateProfileReq})
+ *
+ * </pre>
+ *
+ * @author jack8
+ * @since 2025-12-16
+ */
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Response<Long>> register(@Valid @RequestBody CreateMemberReq req) {
+        Long id = memberService.createMember(req);
+
+        return ResponseEntity.ok(CommonResponse.success(ResponseCode.USER_CREATE, id, "회원가입을 성공하였습니다."));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<Response<MemberDetailsRes>> getProfile(@AuthenticationPrincipal Long userId) {
+        MemberDetailsRes res = memberService.getProfile(userId);
+
+        return ResponseEntity.ok(CommonResponse.success(ResponseCode.USER_UPDATE, res, ""));
+    }
+
+    @PutMapping("/profile")
+    public ResponseEntity<Response<Long>> updateProfile(
+            @AuthenticationPrincipal Long userId, @Valid @RequestBody UpdateProfileReq req) {
+        Long id = memberService.updateProfile(userId, req);
+
+        return ResponseEntity.ok(CommonResponse.success(ResponseCode.USER_UPDATE, id, "프로필 갱신을 성공하였습니다."));
+    }
+}

--- a/src/main/java/com/studypals/domain/memberManage/dto/CreateMemberReq.java
+++ b/src/main/java/com/studypals/domain/memberManage/dto/CreateMemberReq.java
@@ -1,9 +1,6 @@
 package com.studypals.domain.memberManage.dto;
 
-import java.time.LocalDate;
-
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.PastOrPresent;
 
 /**
  * 회원가입 시 사용되는 DTO 입니다.
@@ -13,10 +10,4 @@ import jakarta.validation.constraints.PastOrPresent;
  * @author jack8
  * @since 2025-04-02
  */
-public record CreateMemberReq(
-        @NotBlank String username,
-        @NotBlank String password,
-        @NotBlank String nickname,
-        @PastOrPresent LocalDate birthday,
-        String position,
-        String imageUrl) {}
+public record CreateMemberReq(@NotBlank String username, @NotBlank String password, @NotBlank String nickname) {}

--- a/src/main/java/com/studypals/domain/memberManage/dto/MemberDetailsRes.java
+++ b/src/main/java/com/studypals/domain/memberManage/dto/MemberDetailsRes.java
@@ -2,14 +2,18 @@ package com.studypals.domain.memberManage.dto;
 
 import java.time.LocalDate;
 
+import lombok.Builder;
+
 /**
  * 유저의 세부 정보를 반환할 때 사용됩니다. 보통, 프로필 화면을 구성할 때 사용합니다.
  *
  * @author jack8
  * @since 2025-12-16
  */
+@Builder
 public record MemberDetailsRes(
         Long id,
+        String username,
         String nickname,
         LocalDate birthday,
         String position,

--- a/src/main/java/com/studypals/domain/memberManage/dto/MemberDetailsRes.java
+++ b/src/main/java/com/studypals/domain/memberManage/dto/MemberDetailsRes.java
@@ -1,0 +1,18 @@
+package com.studypals.domain.memberManage.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 유저의 세부 정보를 반환할 때 사용됩니다. 보통, 프로필 화면을 구성할 때 사용합니다.
+ *
+ * @author jack8
+ * @since 2025-12-16
+ */
+public record MemberDetailsRes(
+        Long id,
+        String nickname,
+        LocalDate birthday,
+        String position,
+        String imageUrl,
+        LocalDate createdDate,
+        Long token) {}

--- a/src/main/java/com/studypals/domain/memberManage/dto/UpdateProfileReq.java
+++ b/src/main/java/com/studypals/domain/memberManage/dto/UpdateProfileReq.java
@@ -1,0 +1,15 @@
+package com.studypals.domain.memberManage.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.PastOrPresent;
+
+/**
+ * 사용자의 프로필을 입력/갱신하기 위해 사용하는 DTO 입니다.
+ * <p>
+ * 최초 회원가입 시 필수 정보 및 부가 정보 API 를 분리하였고, 부가 정보 입력 시에도 사용됩니다.
+ *
+ * @author jack8
+ * @since 2025-12-16
+ */
+public record UpdateProfileReq(@PastOrPresent LocalDate birthday, String position, String imageUrl) {}

--- a/src/main/java/com/studypals/domain/memberManage/dto/mappers/MemberMapper.java
+++ b/src/main/java/com/studypals/domain/memberManage/dto/mappers/MemberMapper.java
@@ -1,18 +1,14 @@
 package com.studypals.domain.memberManage.dto.mappers;
 
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
-import com.studypals.domain.memberManage.dto.CreateMemberReq;
+import com.studypals.domain.memberManage.dto.MemberDetailsRes;
 import com.studypals.domain.memberManage.entity.Member;
 
 /**
  * Member 에 대한 mapping 클래스입니다.
  * <p>
  * MapStruct을 통하여 자동으로 구현체가 생성됩니다.
- *
- * <p><b>빈 관리:</b><br>
- * Mapper 어노테이션을 통해 자동으로 빈에 {@code CategoryMapper}로 등록됩니다.
  *
  * <p><b>외부 모듈:</b><br>
  * MapperStruct
@@ -23,9 +19,5 @@ import com.studypals.domain.memberManage.entity.Member;
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
 
-    @Mapping(target = "password", source = "encodedPassword") // password는 별도 인자
-    @Mapping(target = "id", ignore = true) // DB가 자동 생성
-    @Mapping(target = "createdDate", ignore = true) // Auditing에 의해 자동 생성
-    @Mapping(target = "token", ignore = true) // 디폴트값으로 설정됨
-    Member toEntity(CreateMemberReq req, String encodedPassword);
+    MemberDetailsRes toRes(Member member);
 }

--- a/src/main/java/com/studypals/domain/memberManage/entity/Member.java
+++ b/src/main/java/com/studypals/domain/memberManage/entity/Member.java
@@ -62,4 +62,16 @@ public class Member {
     public void addToken(Long token) {
         this.token += token;
     }
+
+    public Member(String username, String password, String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
+    public void updateProfile(LocalDate birthday, String position, String imageUrl) {
+        this.birthday = birthday;
+        this.position = position;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/studypals/domain/memberManage/entity/Member.java
+++ b/src/main/java/com/studypals/domain/memberManage/entity/Member.java
@@ -67,6 +67,7 @@ public class Member {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
+        this.token = 0L;
     }
 
     public void updateProfile(LocalDate birthday, String position, String imageUrl) {

--- a/src/main/java/com/studypals/domain/memberManage/service/MemberService.java
+++ b/src/main/java/com/studypals/domain/memberManage/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.studypals.domain.memberManage.service;
 
 import com.studypals.domain.memberManage.dto.CreateMemberReq;
+import com.studypals.domain.memberManage.dto.MemberDetailsRes;
+import com.studypals.domain.memberManage.dto.UpdateProfileReq;
 
 /**
  * MemberService 의 인터페이스입니다. 메서드를 정의합니다.
@@ -19,4 +21,8 @@ public interface MemberService {
     Long createMember(CreateMemberReq dto);
 
     Long getMemberIdByUsername(String username);
+
+    Long updateProfile(Long userId, UpdateProfileReq dto);
+
+    MemberDetailsRes getProfile(Long userId);
 }

--- a/src/main/java/com/studypals/domain/memberManage/service/MemberServiceImpl.java
+++ b/src/main/java/com/studypals/domain/memberManage/service/MemberServiceImpl.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.memberManage.dto.CreateMemberReq;
+import com.studypals.domain.memberManage.dto.MemberDetailsRes;
+import com.studypals.domain.memberManage.dto.UpdateProfileReq;
 import com.studypals.domain.memberManage.dto.mappers.MemberMapper;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.memberManage.worker.MemberReader;
@@ -34,13 +36,13 @@ public class MemberServiceImpl implements MemberService {
     private final MemberReader memberReader;
     private final MemberWriter memberWriter;
     private final PasswordEncoder passwordEncoder;
-    private final MemberMapper mapper;
+    private final MemberMapper memberMapper;
 
     @Override
     @Transactional
     public Long createMember(CreateMemberReq dto) {
-        String password = passwordEncoder.encode(dto.password());
-        Member member = mapper.toEntity(dto, password);
+        String encoded = passwordEncoder.encode(dto.password());
+        Member member = new Member(dto.username(), encoded, dto.nickname());
 
         memberWriter.save(member);
 
@@ -52,5 +54,24 @@ public class MemberServiceImpl implements MemberService {
     public Long getMemberIdByUsername(String username) {
 
         return memberReader.get(username).getId();
+    }
+
+    @Override
+    @Transactional
+    public Long updateProfile(Long userId, UpdateProfileReq dto) {
+        Member member = memberReader.get(userId);
+
+        member.updateProfile(dto.birthday(), dto.position(), dto.imageUrl());
+
+        memberWriter.save(member);
+
+        return member.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MemberDetailsRes getProfile(Long userId) {
+        Member member = memberReader.get(userId);
+        return memberMapper.toRes(member);
     }
 }

--- a/src/main/java/com/studypals/domain/memberManage/worker/MemberWriter.java
+++ b/src/main/java/com/studypals/domain/memberManage/worker/MemberWriter.java
@@ -31,8 +31,15 @@ public class MemberWriter {
 
         try {
             memberRepository.save(member);
-        } catch (DataIntegrityViolationException e) {
-            throw new AuthException(AuthErrorCode.SIGNUP_FAIL, "maybe duplicate username or nickname");
+        } catch (DataIntegrityViolationException e) { // client message 수정
+            throw new AuthException(
+                    AuthErrorCode.SIGNUP_FAIL,
+                    "[MemberWriter#save] duplicate | " + getDuplicateLogMessage(member),
+                    "username 혹은 nickname 이 중복되었습니다.");
         }
+    }
+
+    private String getDuplicateLogMessage(Member member) {
+        return "username : " + member.getUsername() + " | nickname : " + member.getNickname();
     }
 }

--- a/src/test/java/com/studypals/domain/memberManage/restDocsTest/AuthControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/memberManage/restDocsTest/AuthControllerRestDocsTest.java
@@ -13,8 +13,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -22,7 +20,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.memberManage.api.AuthController;
-import com.studypals.domain.memberManage.dto.CreateMemberReq;
 import com.studypals.domain.memberManage.dto.ReissueTokenRes;
 import com.studypals.domain.memberManage.dto.SignInReq;
 import com.studypals.domain.memberManage.dto.TokenReissueReq;
@@ -56,74 +53,6 @@ class AuthControllerRestDocsTest extends RestDocsSupport {
 
     @MockitoBean
     private TokenService tokenService;
-
-    @Test
-    void register_success() throws Exception {
-
-        // given
-        CreateMemberReq req = new CreateMemberReq(
-                "username", "password", "nickname", LocalDate.of(2000, 1, 1), "student", "example.com");
-
-        Response<Long> expectedResponse =
-                CommonResponse.success(ResponseCode.USER_CREATE, 1L, "success createWithCategory user");
-
-        given(memberService.createMember(req)).willReturn(1L);
-
-        // when
-        ResultActions result = mockMvc.perform(post("/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(req)));
-
-        // then
-        result.andExpect(hasKey(expectedResponse))
-                .andExpect(status().isOk())
-                .andDo(restDocs.document(
-                        httpRequest(),
-                        httpResponse(),
-                        requestFields(
-                                fieldWithPath("username")
-                                        .description("유저의 아이디")
-                                        .attributes(constraints("not null, unique")),
-                                fieldWithPath("password")
-                                        .description("유저의 비밀번호")
-                                        .attributes(constraints("not null")),
-                                fieldWithPath("nickname")
-                                        .description("유저의 닉네임")
-                                        .attributes(constraints("not null, unique")),
-                                fieldWithPath("birthday")
-                                        .description("유저의 생일 / 2024-01-01 형식 사용")
-                                        .attributes(constraints("optional")),
-                                fieldWithPath("position")
-                                        .description("유저의 현재 직업, 상태 등의 그룹 이름")
-                                        .attributes(constraints("optional")),
-                                fieldWithPath("imageUrl")
-                                        .description("유저의 프로필 이미지")
-                                        .attributes(constraints("optional"))),
-                        responseFields(
-                                fieldWithPath("data").description("생성된 user의 id/식별자"),
-                                fieldWithPath("code").description("U01-01 고정"),
-                                fieldWithPath("status").description("응답 상태 (예: success 또는 fail)"),
-                                fieldWithPath("message").description("응답 메시지"))));
-    }
-
-    @Test
-    void register_fail_duplicate_user() throws Exception {
-        // given
-        CreateMemberReq duplicateUserReq = new CreateMemberReq(
-                "username", "password1", "nickname1", LocalDate.of(2000, 1, 1), "student", "example.com");
-
-        AuthErrorCode errorCode = AuthErrorCode.SIGNUP_FAIL;
-
-        given(memberService.createMember(duplicateUserReq)).willThrow(new AuthException(errorCode));
-
-        // when
-        ResultActions result = mockMvc.perform(post("/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(duplicateUserReq)));
-
-        // then
-        result.andExpect(hasStatus(errorCode)).andExpect(hasKey(errorCode)).andDo(restDocs.document(httpResponse()));
-    }
 
     @Test
     void login_success() throws Exception {

--- a/src/test/java/com/studypals/domain/memberManage/restDocsTest/MemberControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/memberManage/restDocsTest/MemberControllerRestDocsTest.java
@@ -1,0 +1,179 @@
+package com.studypals.domain.memberManage.restDocsTest;
+
+import static com.studypals.testModules.testUtils.JsonFieldResultMatcher.hasKey;
+import static com.studypals.testModules.testUtils.JsonFieldResultMatcher.hasStatus;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.http.HttpDocumentation.httpRequest;
+import static org.springframework.restdocs.http.HttpDocumentation.httpResponse;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.studypals.domain.memberManage.api.MemberController;
+import com.studypals.domain.memberManage.dto.CreateMemberReq;
+import com.studypals.domain.memberManage.dto.MemberDetailsRes;
+import com.studypals.domain.memberManage.dto.UpdateProfileReq;
+import com.studypals.domain.memberManage.service.MemberService;
+import com.studypals.global.exceptions.errorCode.AuthErrorCode;
+import com.studypals.global.exceptions.exception.AuthException;
+import com.studypals.global.responses.CommonResponse;
+import com.studypals.global.responses.Response;
+import com.studypals.global.responses.ResponseCode;
+import com.studypals.testModules.testSupport.RestDocsSupport;
+
+/**
+ * {@link MemberController} 에 대한 rest docs web mvc test 입니다. 문서를 생성합니다.
+ *
+ * @author jack8
+ * @see MemberController
+ * @see RestDocsSupport
+ * @since 2025-12-16
+ */
+@WebMvcTest(MemberController.class)
+public class MemberControllerRestDocsTest extends RestDocsSupport {
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @Test
+    void register_success() throws Exception {
+
+        // given
+        CreateMemberReq req = new CreateMemberReq("username", "password", "nickname");
+
+        Response<Long> expectedResponse = CommonResponse.success(ResponseCode.USER_CREATE, 1L, "회원가입을 성공하였습니다.");
+
+        given(memberService.createMember(req)).willReturn(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(hasKey(expectedResponse))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        httpRequest(),
+                        httpResponse(),
+                        requestFields(
+                                fieldWithPath("username")
+                                        .description("유저의 아이디")
+                                        .attributes(constraints("not null, unique")),
+                                fieldWithPath("password")
+                                        .description("유저의 비밀번호")
+                                        .attributes(constraints("not null")),
+                                fieldWithPath("nickname")
+                                        .description("유저의 닉네임")
+                                        .attributes(constraints("not null, unique"))),
+                        responseFields(
+                                fieldWithPath("data").description("생성된 user의 id/식별자"),
+                                fieldWithPath("code").description("U01-01 고정"),
+                                fieldWithPath("status").description("응답 상태 (예: success 또는 fail)"),
+                                fieldWithPath("message").description("응답 메시지"))));
+    }
+
+    @Test
+    void register_fail_duplicate_user() throws Exception {
+        // given
+        CreateMemberReq duplicateUserReq = new CreateMemberReq("username", "password1", "nickname1");
+
+        AuthErrorCode errorCode = AuthErrorCode.SIGNUP_FAIL;
+
+        given(memberService.createMember(duplicateUserReq)).willThrow(new AuthException(errorCode));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(duplicateUserReq)));
+
+        // then
+        result.andExpect(hasStatus(errorCode)).andExpect(hasKey(errorCode)).andDo(restDocs.document(httpResponse()));
+    }
+
+    @Test
+    @WithMockUser
+    void getProfile_success() throws Exception {
+        // given
+        MemberDetailsRes memberDetailsRes = MemberDetailsRes.builder()
+                .id(1L)
+                .username("username@example.com")
+                .nickname("nickname")
+                .birthday(LocalDate.of(1999, 8, 20))
+                .position("student")
+                .imageUrl("example.image.com")
+                .createdDate(LocalDate.of(2025, 1, 1))
+                .token(412L)
+                .build();
+        given(memberService.getProfile(any())).willReturn(memberDetailsRes);
+
+        Response<MemberDetailsRes> response = CommonResponse.success(ResponseCode.USER_UPDATE, memberDetailsRes, "");
+
+        // when
+        ResultActions result = mockMvc.perform(get("/profile").contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(hasKey(response))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        httpRequest(),
+                        httpResponse(),
+                        responseFields(
+                                fieldWithPath("code").description("응답 코드 (U01-02)"),
+                                fieldWithPath("status").description("응답 상태"),
+                                fieldWithPath("message").description("응답 메시지"),
+                                fieldWithPath("data").description("회원 정보"),
+                                fieldWithPath("data.id").description("회원 ID"),
+                                fieldWithPath("data.username").description("사용자 아이디(이메일)"),
+                                fieldWithPath("data.nickname").description("닉네임"),
+                                fieldWithPath("data.birthday").description("생일").optional(),
+                                fieldWithPath("data.position").description("직업").optional(),
+                                fieldWithPath("data.imageUrl")
+                                        .description("프로필 이미지 URL")
+                                        .optional(),
+                                fieldWithPath("data.createdDate").description("계정 생성일"),
+                                fieldWithPath("data.token").description("토큰 개수").optional())));
+    }
+
+    @Test
+    @WithMockUser
+    void updateProfile_success() throws Exception {
+        // given
+        UpdateProfileReq req = new UpdateProfileReq(LocalDate.of(1999, 8, 20), "학생", "exmaple.image.com");
+
+        given(memberService.updateProfile(anyLong(), any(UpdateProfileReq.class)))
+                .willReturn(1L);
+
+        // when
+        ResultActions result = mockMvc.perform(
+                put("/profile").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        httpRequest(),
+                        httpResponse(),
+                        requestFields(
+                                fieldWithPath("birthday").description("생일").optional(),
+                                fieldWithPath("position").description("직무/포지션").optional(),
+                                fieldWithPath("imageUrl")
+                                        .description("프로필 이미지 URL")
+                                        .optional()),
+                        responseFields(
+                                fieldWithPath("code").description("응답 코드 (U01-02)"),
+                                fieldWithPath("status").description("응답 상태"),
+                                fieldWithPath("data").description("수정된 회원 ID"),
+                                fieldWithPath("message").description("응답 메시지"))));
+    }
+}

--- a/src/test/java/com/studypals/integrationTest/AuthIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/AuthIntegrationTest.java
@@ -5,8 +5,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +13,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.studypals.domain.memberManage.dao.RefreshTokenRedisRepository;
-import com.studypals.domain.memberManage.dto.CreateMemberReq;
 import com.studypals.domain.memberManage.dto.SignInReq;
 import com.studypals.domain.memberManage.dto.TokenReissueReq;
 import com.studypals.domain.memberManage.entity.RefreshToken;
@@ -57,25 +54,6 @@ public class AuthIntegrationTest extends IntegrationSupport {
                 .andExpect(jsonPath("$.data.refreshToken").exists())
                 .andExpect(jsonPath("$.data.accessToken").exists())
                 .andExpect(jsonPath("$.data.grantType").exists());
-    }
-
-    @Test
-    @DisplayName("POST /register")
-    void register_success() throws Exception {
-        // given
-        CreateMemberReq req = new CreateMemberReq(
-                "username", "password", "nickname", LocalDate.of(2000, 1, 1), "student", "example.com");
-
-        // when
-        ResultActions response = mockMvc.perform(post("/register")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(req)));
-
-        // then
-        response.andExpect(status().isOk())
-                .andExpect(hasKey("code", ResponseCode.USER_CREATE.getCode()))
-                .andExpect(hasKey("message", "success createWithCategory user"))
-                .andExpect(jsonPath("$.data").exists());
     }
 
     @Test


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #129

## ✨ 구현 기능 명세

회원가입 시 필수 정보 및 부가 정보 API 를 분리하였습니다. 부가 정보 입력 API 는 사실 상 이미 등록된 사용자의 데이터를 갱신하는 로직이라 판단하여, PUT 으로 두었으며, 이후 자신의 프로필 수정 시 동일한 엔드포인트를 사용하도록 명시하였습니다.

## ✅ PR Point

- Member 내부에  필수 정보를 기반으로 한 생성자(인자 3개)와, 부가 정보 갱신을 위한 update 메서드를 두었습니다. builder 는 테스트 등에서 사용하기 위해 삭제하지 않았습니다. 따라서, mapper 또한 사라졌습니다.
