### PR TITLE
[#128][FEATURE] 공부 시작 시 유효한 studyTime 반환

### DIFF
--- a/src/main/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapper.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapper.java
@@ -19,7 +19,8 @@ import com.studypals.domain.studyManage.entity.StudyTime;
 @Mapper(componentModel = "spring")
 public interface StudyTimeMapper {
 
-    StartStudyRes toDto(StudyStatus entity);
+    @Mapping(target = "studyTime", source = "studyTime")
+    StartStudyRes toDto(StudyStatus entity, Long studyTime);
 
     @Mapping(target = "categoryId", source = "studyCategory.id")
     GetStudyDto toDto(StudyTime entity);

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
@@ -46,9 +46,6 @@ public class StudyStatus {
 
     private LocalDateTime startTime;
 
-    //    @Builder.Default
-    //    private Long studyTime = 0L; // 이번 pr에서 유효한 값으로 만들어야함
-
     private Long categoryId;
 
     private String name;

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
@@ -39,15 +39,15 @@ import lombok.Setter;
 @Getter
 public class StudyStatus {
     @Id
-    private Long id;
+    private Long id; // 해당 공부 상태를 가진 userId
 
     @Builder.Default
     private boolean studying = true;
 
     private LocalDateTime startTime;
 
-    @Builder.Default
-    private Long studyTime = 0L;
+//    @Builder.Default
+//    private Long studyTime = 0L; // 이번 pr에서 유효한 값으로 만들어야함
 
     private Long categoryId;
 

--- a/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
+++ b/src/main/java/com/studypals/domain/studyManage/entity/StudyStatus.java
@@ -46,8 +46,8 @@ public class StudyStatus {
 
     private LocalDateTime startTime;
 
-//    @Builder.Default
-//    private Long studyTime = 0L; // 이번 pr에서 유효한 값으로 만들어야함
+    //    @Builder.Default
+    //    private Long studyTime = 0L; // 이번 pr에서 유효한 값으로 만들어야함
 
     private Long categoryId;
 

--- a/src/main/java/com/studypals/domain/studyManage/service/StudySessionServiceImpl.java
+++ b/src/main/java/com/studypals/domain/studyManage/service/StudySessionServiceImpl.java
@@ -179,7 +179,9 @@ public class StudySessionServiceImpl implements StudySessionService {
 
         // 공부 시작을 하고, 24시간 후에 다시 공부 시작을 하는 경우 예외 발생
         if (timeUtils.exceeds24Hours(durationSeconds)) {
-            throw new StudyException(StudyErrorCode.STUDY_TIME_START_FAIL);
+            throw new StudyException(
+                    StudyErrorCode.STUDY_TIME_START_FAIL,
+                    "[StudySessionServiceImpl#startStudy] over 1 day pass is invalid");
         }
 
         return mapper.toDto(status, durationSeconds);

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -3,7 +3,6 @@ package com.studypals.domain.studyManage.worker;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.studyManage.dao.StudyStatusRedisRepository;
@@ -23,7 +22,6 @@ import com.studypals.global.exceptions.exception.StudyException;
  * @see StudyStatus
  * @since 2025-04-15
  */
-@Slf4j
 @Worker
 @RequiredArgsConstructor
 public class StudyStatusWorker {
@@ -55,20 +53,19 @@ public class StudyStatusWorker {
     }
 
     /**
-     * id로 StudyStatus 을 찾아보고, 존재하면 그대로 반환하고, 존재하지 않으면 새로운 객체를 만들어 반환합니다. <br>
+     * StudyStatus 를 생성하고 적절한 값을 넣어 반환 <br>
      * @param dto 공부 데이터
      * @return 만들어진 객체
      */
     public StudyStatus startStatus(Member member, StartStudyDto dto) {
-        Optional<StudyStatus> optionalStudyStatus = find(member.getId());
         // 새로운 optionalStudyStatus 를 생성하여 반환
-        return optionalStudyStatus.orElseGet(() -> StudyStatus.builder()
+        return StudyStatus.builder()
                 .id(member.getId())
                 .categoryId(dto.categoryId())
                 .studying(true)
                 .startTime(dto.startDateTime())
                 .name(dto.temporaryName())
-                .build());
+                .build();
     }
 
     /**
@@ -120,18 +117,4 @@ public class StudyStatusWorker {
             throw new StudyException(StudyErrorCode.STUDY_TIME_END_FAIL, "save fail");
         }
     }
-    //
-    //    /**
-    //     * 공부를 마무리하고, studyStatus.studyTime 을 time 만큼 증가시킵니다.
-    //     * @param status 유저의 공부 상태
-    //     * @param time 유저가 공부한 시간
-    //     */
-    //    public void addStudyTimeAndSave(StudyStatus status, Long time) {
-    //        StudyStatus updatedStatus = status.update()
-    //                .studying(false)
-    //                .studyTime(status.getStudyTime() + time)
-    //                .build();
-    //        log.info("updatedStatus id = {}", updatedStatus.getId());
-    //        saveStatus(updatedStatus);
-    //    }
 }

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -53,12 +53,12 @@ public class StudyStatusWorker {
     }
 
     /**
-     * StudyStatus 를 생성하고 적절한 값을 넣어 반환 <br>
+     * StudyStatus 를 생성하고 반환 <br>
      * @param dto 공부 데이터
      * @return 만들어진 객체
      */
     public StudyStatus startStatus(Member member, StartStudyDto dto) {
-        // 새로운 optionalStudyStatus 를 생성하여 반환
+        // 새로운 StudyStatus 생성 후 반환
         return StudyStatus.builder()
                 .id(member.getId())
                 .categoryId(dto.categoryId())

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -11,6 +11,7 @@ import com.studypals.domain.studyManage.entity.StudyStatus;
 import com.studypals.global.annotations.Worker;
 import com.studypals.global.exceptions.errorCode.StudyErrorCode;
 import com.studypals.global.exceptions.exception.StudyException;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * 공부 상태를 나타내는 studyStatus 의 저장/조회 및, 해당 객체의 생성 등을 담당합니다.
@@ -22,6 +23,7 @@ import com.studypals.global.exceptions.exception.StudyException;
  * @see StudyStatus
  * @since 2025-04-15
  */
+@Slf4j
 @Worker
 @RequiredArgsConstructor
 public class StudyStatusWorker {
@@ -39,7 +41,7 @@ public class StudyStatusWorker {
 
     /**
      * id 에 대해 studyStatus 를 검색하고, 이를 삭제합니다.
-     * @param id 검새갛고자 하는 id(userId)
+     * @param id 검색하고자 하는 id(userId)
      * @return Optional - study status
      */
     public Optional<StudyStatus> findAndDelete(Long id) {
@@ -53,20 +55,20 @@ public class StudyStatusWorker {
     }
 
     /**
-     * StudyStatus 를 생성하고 적절한 값을 넣어 반환 <br>
+     * id로 StudyStatus 을 찾아보고, 존재하면 그대로 반환하고, 존재하지 않으면 새로운 객체를 만들어 반환합니다. <br>
      * @param dto 공부 데이터
      * @return 만들어진 객체
      */
     public StudyStatus startStatus(Member member, StartStudyDto dto) {
-
-        // 새로운 studyStatus 를 생성하여 반환
-        return StudyStatus.builder()
+        Optional<StudyStatus> optionalStudyStatus = find(member.getId());
+        // 새로운 optionalStudyStatus 를 생성하여 반환
+        return optionalStudyStatus.orElseGet(() -> StudyStatus.builder()
                 .id(member.getId())
                 .categoryId(dto.categoryId())
                 .studying(true)
                 .startTime(dto.startDateTime())
                 .name(dto.temporaryName())
-                .build();
+                .build());
     }
 
     /**
@@ -118,4 +120,18 @@ public class StudyStatusWorker {
             throw new StudyException(StudyErrorCode.STUDY_TIME_END_FAIL, "save fail");
         }
     }
+//
+//    /**
+//     * 공부를 마무리하고, studyStatus.studyTime 을 time 만큼 증가시킵니다.
+//     * @param status 유저의 공부 상태
+//     * @param time 유저가 공부한 시간
+//     */
+//    public void addStudyTimeAndSave(StudyStatus status, Long time) {
+//        StudyStatus updatedStatus = status.update()
+//                .studying(false)
+//                .studyTime(status.getStudyTime() + time)
+//                .build();
+//        log.info("updatedStatus id = {}", updatedStatus.getId());
+//        saveStatus(updatedStatus);
+//    }
 }

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyStatusWorker.java
@@ -3,6 +3,7 @@ package com.studypals.domain.studyManage.worker;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.studyManage.dao.StudyStatusRedisRepository;
@@ -11,7 +12,6 @@ import com.studypals.domain.studyManage.entity.StudyStatus;
 import com.studypals.global.annotations.Worker;
 import com.studypals.global.exceptions.errorCode.StudyErrorCode;
 import com.studypals.global.exceptions.exception.StudyException;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * 공부 상태를 나타내는 studyStatus 의 저장/조회 및, 해당 객체의 생성 등을 담당합니다.
@@ -120,18 +120,18 @@ public class StudyStatusWorker {
             throw new StudyException(StudyErrorCode.STUDY_TIME_END_FAIL, "save fail");
         }
     }
-//
-//    /**
-//     * 공부를 마무리하고, studyStatus.studyTime 을 time 만큼 증가시킵니다.
-//     * @param status 유저의 공부 상태
-//     * @param time 유저가 공부한 시간
-//     */
-//    public void addStudyTimeAndSave(StudyStatus status, Long time) {
-//        StudyStatus updatedStatus = status.update()
-//                .studying(false)
-//                .studyTime(status.getStudyTime() + time)
-//                .build();
-//        log.info("updatedStatus id = {}", updatedStatus.getId());
-//        saveStatus(updatedStatus);
-//    }
+    //
+    //    /**
+    //     * 공부를 마무리하고, studyStatus.studyTime 을 time 만큼 증가시킵니다.
+    //     * @param status 유저의 공부 상태
+    //     * @param time 유저가 공부한 시간
+    //     */
+    //    public void addStudyTimeAndSave(StudyStatus status, Long time) {
+    //        StudyStatus updatedStatus = status.update()
+    //                .studying(false)
+    //                .studyTime(status.getStudyTime() + time)
+    //                .build();
+    //        log.info("updatedStatus id = {}", updatedStatus.getId());
+    //        saveStatus(updatedStatus);
+    //    }
 }

--- a/src/main/java/com/studypals/global/utils/TimeUtils.java
+++ b/src/main/java/com/studypals/global/utils/TimeUtils.java
@@ -45,6 +45,11 @@ public class TimeUtils {
         }
     }
 
+    public LocalTime getTime() {
+        LocalDateTime now = LocalDateTime.now(clock);
+        return now.toLocalTime();
+    }
+
     public LocalDate getToday() {
         LocalDateTime now = LocalDateTime.now(clock);
 

--- a/src/main/java/com/studypals/global/utils/TimeUtils.java
+++ b/src/main/java/com/studypals/global/utils/TimeUtils.java
@@ -30,7 +30,7 @@ public class TimeUtils {
     private final Clock clock;
     private final StringRedisTemplate redisTemplate;
 
-    private static final LocalTime CUTOFF = LocalTime.of(6, 0);
+    public static final LocalTime CUTOFF = LocalTime.of(6, 0);
     private static final int SECS_PER_DAY = 24 * 60 * 60;
 
     private static final String OVERRIDE_KEY = "timeutils:override:now";

--- a/src/main/java/com/studypals/global/utils/TimeUtils.java
+++ b/src/main/java/com/studypals/global/utils/TimeUtils.java
@@ -31,6 +31,7 @@ public class TimeUtils {
     private final StringRedisTemplate redisTemplate;
 
     private static final LocalTime CUTOFF = LocalTime.of(6, 0);
+    private static final int SECS_PER_DAY = 24 * 60 * 60;
 
     private static final String OVERRIDE_KEY = "timeutils:override:now";
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd:HH:mm:ss");
@@ -48,6 +49,24 @@ public class TimeUtils {
     public LocalTime getTime() {
         LocalDateTime now = LocalDateTime.now(clock);
         return now.toLocalTime();
+    }
+
+    /**
+     * 시작 시간과 종료 시간에 대해 second로 반환하는 메서드.
+     * 00:00 을 기점으로 계산 로직이 달라진다.
+     * @param start 공부 시작 시간
+     * @param end 공부 종료 시간
+     * @return 초 단위 공부 시간
+     */
+    public long getTimeDuration(LocalTime start, LocalTime end) {
+        int s = start.toSecondOfDay();
+        int e = end.toSecondOfDay();
+        if (s == e) return 0L;
+        return (e >= s) ? (e - s) : (SECS_PER_DAY - s) + e;
+    }
+
+    public boolean exceeds24Hours(Long seconds) {
+        return seconds > SECS_PER_DAY;
     }
 
     public LocalDate getToday() {

--- a/src/test/java/com/studypals/domain/studyManage/dao/StudyStatusRedisRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/dao/StudyStatusRedisRepositoryTest.java
@@ -42,7 +42,6 @@ class StudyStatusRedisRepositoryTest {
         StudyStatus status = StudyStatus.builder()
                 .id(1L)
                 .startTime(LocalDateTime.of(2025, 8, 20, 10, 0))
-                .studyTime(120L)
                 .expiration(1L)
                 .build();
 
@@ -52,7 +51,6 @@ class StudyStatusRedisRepositoryTest {
 
         // then
         assertThat(result).isPresent();
-        assertThat(result.get().getStudyTime()).isEqualTo(120L);
     }
 
     @Test
@@ -61,7 +59,6 @@ class StudyStatusRedisRepositoryTest {
         StudyStatus status = StudyStatus.builder()
                 .id(2L)
                 .startTime(LocalDateTime.of(2025, 8, 20, 12, 0))
-                .studyTime(90L)
                 .expiration(1L)
                 .build();
         studyStatusRedisRepository.save(status);

--- a/src/test/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapperTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapperTest.java
@@ -2,6 +2,7 @@ package com.studypals.domain.studyManage.dto.mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -33,19 +34,17 @@ class StudyTimeMapperTest {
         LocalDateTime startTime = LocalDateTime.of(2025, 8, 20, 10, 30);
         StudyStatus entity = StudyStatus.builder()
                 .id(1L)
-                .studyTime(100L)
                 .startTime(startTime)
                 .categoryId(1L)
                 .name("temp")
                 .build();
-
         // when
-        StartStudyRes dto = mapper.toDto(entity);
+        StartStudyRes dto = mapper.toDto(entity, 120L);
 
         // then
         assertThat(dto.studying()).isTrue();
         assertThat(dto.startTime()).isEqualTo(startTime);
-        assertThat(dto.studyTime()).isEqualTo(100L);
+        assertThat(dto.studyTime()).isEqualTo(120L);
         assertThat(dto.categoryId()).isEqualTo(1L);
         assertThat(dto.name()).isEqualTo("temp");
     }
@@ -54,9 +53,6 @@ class StudyTimeMapperTest {
     @DisplayName("StudyTime → GetStudyDto 매핑 성공")
     void toDto_success_studyTimeToGetStudyDto() {
         // given
-        StudyCategory category =
-                StudyCategory.builder().id(7L).name("algorithm").build();
-
         StudyTime studyTime = StudyTime.builder()
                 .id(1L)
                 .name("temp")

--- a/src/test/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapperTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/dto/mappers/StudyTimeMapperTest.java
@@ -2,7 +2,6 @@ package com.studypals.domain.studyManage.dto.mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -14,7 +13,6 @@ import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.studyManage.dto.GetStudyDto;
 import com.studypals.domain.studyManage.dto.StartStudyRes;
 import com.studypals.domain.studyManage.dto.StudyStatusRes;
-import com.studypals.domain.studyManage.entity.StudyCategory;
 import com.studypals.domain.studyManage.entity.StudyStatus;
 import com.studypals.domain.studyManage.entity.StudyTime;
 

--- a/src/test/java/com/studypals/domain/studyManage/worker/StudyStatusWorkerTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/StudyStatusWorkerTest.java
@@ -100,8 +100,7 @@ class StudyStatusWorkerTest {
     @Test
     void validStatus_fail_whenInvalidStudyState() {
         // given
-        StudyStatus invalid =
-                StudyStatus.builder().id(1L).studying(false).build();
+        StudyStatus invalid = StudyStatus.builder().id(1L).studying(false).build();
 
         // when & then
         assertThatThrownBy(() -> studyStatusWorker.validStatus(invalid))

--- a/src/test/java/com/studypals/domain/studyManage/worker/StudyStatusWorkerTest.java
+++ b/src/test/java/com/studypals/domain/studyManage/worker/StudyStatusWorkerTest.java
@@ -40,7 +40,7 @@ class StudyStatusWorkerTest {
     void find_AndDelete_success() {
         // given
         Long userId = 1L;
-        StudyStatus status = StudyStatus.builder().id(userId).studyTime(120L).build();
+        StudyStatus status = StudyStatus.builder().id(userId).build();
         given(studyStatusRedisRepository.findById(userId)).willReturn(Optional.of(status));
 
         // when
@@ -101,7 +101,7 @@ class StudyStatusWorkerTest {
     void validStatus_fail_whenInvalidStudyState() {
         // given
         StudyStatus invalid =
-                StudyStatus.builder().id(1L).studying(false).studyTime(60L).build();
+                StudyStatus.builder().id(1L).studying(false).build();
 
         // when & then
         assertThatThrownBy(() -> studyStatusWorker.validStatus(invalid))


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #128 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
### 기존 배경
유저가 공부 start를 한 상태에서 또 start를 하는 경우 공부 시간을 반환하기 위해 StudyStatus 의 studyTime 필드를 도입했습니다.
현재 StudyStatus는 redis에 저장하고 있고, 세션과 같이 관리하고 있기에 공부 시작과 종료 사이에만 존재합니다.

- 공부 start 하면 redis 에 새로 생성 (있으면 기존 것을 반환)
- 공부 end 하면 redis 에서 삭제 (더 이상 공부를 하지 않기 때문)

하지만 studyTime 값을 갱신해주는 로직이 없어 항상 기본값인 0으로 반환됩니다. 이를 유효한 값으로 반환하려고 했습니다.

하지만 **notion에서 이야기한대로, studyTime 필드를 유지할 필요가 없다고 생각하여, 삭제하기로 했습니다.**
> notion 링크 : https://www.notion.so/studystatus-2cd9f22b158780be92e6cbfd638aa177?source=copy_link

### 로직 수정 사항
- StudyStatus 의 studyTime 필드를 삭제했습니다.
- 대신에 프론트엔드에서 공부 시작 시, 공부 시간을 요구했기 때문에 `현재 서버 시간 - 최초 공부 시작 시간` 방식으로 시간을 구하고, Response에 담도록 수정했습니다.

### 코드 리팩토링 사항
- 아래 코드는 시간을 다루므로 `TimeUtils`에서 담당하는게 좋아보여서 `StudySessionServiceImpl`에서 `TimeUtils`로 이동했습니다. 그에 따라 해당 메서드에서만 사용하던 `SECS_PER_DAY` 변수도 동일하게 `TimeUtils`로 이동하고 private으로 변경했습니다.
```java
private static final int SECS_PER_DAY = 24 * 60 * 60;

public long getTimeDuration(LocalTime start, LocalTime end) {
        int s = start.toSecondOfDay();
        int e = end.toSecondOfDay();
        if (s == e) return 0L;
        return (e >= s) ? (e - s) : (SECS_PER_DAY - s) + e;
    }
```
- 현재 저희 서비스의 날짜 기점를 의미하는 CUTOFF 상수의 경우 `StudySessionServiceImpl`에서 `TimeUtils` 모두에서 사용하고 있습니다. 기존에`StudySessionServiceImpl`에서 CUTOFF 와 동일한 의미로 사용하고 있는 pointTime 변수를 삭제하고, 상수인 CUTOFF 를 사용하도록 변경했습니다. (private -> public 상수로 변경했습니다)

변경 전
```java
       LocalTime pointTime = LocalTime.of(6, 0); // CUTOFF 상수와 중복된 변수입니다. 이를 삭제하였습니다.
       long day1DurationInSec = getTimeDuration(startTime, pointTime);
       long day2DurationInSec = getTimeDuration(pointTime, endTime);
```
변경 후
```java
      long day1DurationInSec = timeUtils.getTimeDuration(startTime, TimeUtils.CUTOFF);
      long day2DurationInSec = timeUtils.getTimeDuration(TimeUtils.CUTOFF, endTime);
```
## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
StudyStatus가 세션 방식으로 관리되는 만큼 StudyStatus 의 필드인 studyTime을 갱신할 수 없고, 이미 startTime 필드가 존재하므로,  
`현재 서버 시간 - 최초 공부 시작 시간` 방식으로 현재 사용자의 공부 시간을 구할 수 있다고 생각했습니다. 

## 😭 어려웠던 점
studystatus가 자꾸 없어져서 왜 그런가 삽질했었는데, 알고보니 endStudy 하면 날라가는걸 뒤늦게 확인했습니다... 하하

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
