### PR TITLE
[#139][HOTFIX] 그룹 조회 API 에 추가 정보 반환

### DIFF
--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
@@ -1,11 +1,11 @@
 package com.studypals.domain.groupManage.dao;
 
-import com.studypals.domain.groupManage.dto.GroupMemberProfileImageDto;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.groupManage.dto.GroupMemberProfileDto;
+import com.studypals.domain.groupManage.dto.GroupMemberProfileMappingDto;
 
 /**
  * {@link com.studypals.domain.groupManage.entity.GroupMember} 엔티티에 대한 커스텀 dao 클래스입니다.
@@ -39,9 +39,9 @@ public interface GroupMemberCustomRepository {
     List<GroupMemberProfileDto> findAllMemberProfiles(Long groupId);
 
     /**
-     * 여러 그룹에 속한 모든 멤버의 간략한 정보(id,imageUrl,role)를 한번에 조회합니다.
+     * 여러 그룹에 속한 모든 멤버의 정보(id,nickname,imageUrl,role)를 한번에 조회합니다.
      * @param groupIds
      * @return
      */
-    List<GroupMemberProfileDto> findAllMembersInGroupIds(List<Long> groupIds);
+    List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds);
 }

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
@@ -43,5 +43,5 @@ public interface GroupMemberCustomRepository {
      * @param groupIds
      * @return
      */
-    List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds);
+    List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds, int limit);
 }

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
@@ -43,5 +43,5 @@ public interface GroupMemberCustomRepository {
      * @param groupIds
      * @return
      */
-    List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds, int limit);
+    List<GroupMemberProfileMappingDto> findTopNMemberInGroupIds(List<Long> groupIds, int limit);
 }

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepository.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.groupManage.dao;
 
+import com.studypals.domain.groupManage.dto.GroupMemberProfileImageDto;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
@@ -31,9 +32,16 @@ public interface GroupMemberCustomRepository {
     List<GroupMemberProfileDto> findTopNMemberByJoinedAt(Long groupId, int limit);
 
     /**
-     * 그룹에 속한 모든 멤버를 조회합니다.
+     * 그룹에 속한 모든 멤버 정보 (id,nickname,imageUrl,role)를 조회합니다.
      * @param groupId 조회할 그룹 ID
-     * @return 멤버 프로필 리스트
+     * @return 멤버 정보 리스트
      */
     List<GroupMemberProfileDto> findAllMemberProfiles(Long groupId);
+
+    /**
+     * 여러 그룹에 속한 모든 멤버의 간략한 정보(id,imageUrl,role)를 한번에 조회합니다.
+     * @param groupIds
+     * @return
+     */
+    List<GroupMemberProfileDto> findAllMembersInGroupIds(List<Long> groupIds);
 }

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
@@ -3,7 +3,6 @@ package com.studypals.domain.groupManage.dao;
 import static com.studypals.domain.groupManage.entity.QGroupMember.groupMember;
 import static com.studypals.domain.memberManage.entity.QMember.member;
 
-import com.studypals.domain.groupManage.dto.GroupMemberProfileImageDto;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -13,6 +12,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.studypals.domain.groupManage.dto.GroupMemberProfileDto;
+import com.studypals.domain.groupManage.dto.GroupMemberProfileMappingDto;
 import com.studypals.domain.groupManage.entity.GroupRole;
 
 /**
@@ -62,10 +62,15 @@ public class GroupMemberCustomRepositoryImpl implements GroupMemberCustomReposit
     }
 
     @Override
-    public List<GroupMemberProfileDto> findAllMembersInGroupIds(List<Long> groupIds) {
+    public List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds) {
         return queryFactory
                 .select(Projections.constructor(
-                        GroupMemberProfileDto.class, member.id, member.nickname, member.imageUrl, groupMember.role))
+                        GroupMemberProfileMappingDto.class,
+                        groupMember.group.id,
+                        member.id,
+                        member.nickname,
+                        member.imageUrl,
+                        groupMember.role))
                 .from(groupMember)
                 .join(member)
                 .on(groupMember.member.id.eq(member.id))

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.studypals.domain.groupManage.dao;
 import static com.studypals.domain.groupManage.entity.QGroupMember.groupMember;
 import static com.studypals.domain.memberManage.entity.QMember.member;
 
+import com.studypals.domain.groupManage.dto.GroupMemberProfileImageDto;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -56,6 +57,19 @@ public class GroupMemberCustomRepositoryImpl implements GroupMemberCustomReposit
                 .join(member)
                 .on(groupMember.member.id.eq(member.id))
                 .where(groupMember.group.id.eq(groupId))
+                .orderBy(orderByLeaderPriority(), groupMember.joinedAt.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<GroupMemberProfileDto> findAllMembersInGroupIds(List<Long> groupIds) {
+        return queryFactory
+                .select(Projections.constructor(
+                        GroupMemberProfileDto.class, member.id, member.nickname, member.imageUrl, groupMember.role))
+                .from(groupMember)
+                .join(member)
+                .on(groupMember.member.id.eq(member.id))
+                .where(groupMember.group.id.in(groupIds))
                 .orderBy(orderByLeaderPriority(), groupMember.joinedAt.desc())
                 .fetch();
     }

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
@@ -62,7 +62,7 @@ public class GroupMemberCustomRepositoryImpl implements GroupMemberCustomReposit
     }
 
     @Override
-    public List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds, int limit) {
+    public List<GroupMemberProfileMappingDto> findTopNMemberInGroupIds(List<Long> groupIds, int limit) {
         return queryFactory
                 .select(Projections.constructor(
                         GroupMemberProfileMappingDto.class,

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberCustomRepositoryImpl.java
@@ -62,13 +62,11 @@ public class GroupMemberCustomRepositoryImpl implements GroupMemberCustomReposit
     }
 
     @Override
-    public List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds) {
+    public List<GroupMemberProfileMappingDto> findAllMembersInGroupIds(List<Long> groupIds, int limit) {
         return queryFactory
                 .select(Projections.constructor(
                         GroupMemberProfileMappingDto.class,
                         groupMember.group.id,
-                        member.id,
-                        member.nickname,
                         member.imageUrl,
                         groupMember.role))
                 .from(groupMember)
@@ -76,6 +74,7 @@ public class GroupMemberCustomRepositoryImpl implements GroupMemberCustomReposit
                 .on(groupMember.member.id.eq(member.id))
                 .where(groupMember.group.id.in(groupIds))
                 .orderBy(orderByLeaderPriority(), groupMember.joinedAt.desc())
+                .limit(limit)
                 .fetch();
     }
 

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberRepository.java
@@ -34,7 +34,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
      * @param memberId 사용자 아이디
      * @return GroupMember 에 대한 List
      */
-    List<GroupMember> findAllByMemberId(Long memberId); // 실험을 해보자.
+    List<GroupMember> findAllByMemberId(Long memberId);
 
     @Query(
             """

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupMemberRepository.java
@@ -39,7 +39,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
     @Query(
             """
       SELECT new com.studypals.domain.groupManage.dto.GroupSummaryDto(
-            g.id, g.name, g.tag, g.chatRoom.id, g.isOpen, g.isApprovalRequired, g.createdDate
+            g.id, g.name, g.tag, g.totalMember, g.chatRoom.id, g.isOpen, g.isApprovalRequired, g.createdDate
       )
       FROM GroupMember gm
       JOIN gm.group g

--- a/src/main/java/com/studypals/domain/groupManage/dto/GetGroupsRes.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GetGroupsRes.java
@@ -1,8 +1,9 @@
 package com.studypals.domain.groupManage.dto;
 
-import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import java.time.LocalDate;
 import java.util.List;
+
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 
 public record GetGroupsRes(
         Long groupId,
@@ -14,7 +15,8 @@ public record GetGroupsRes(
         LocalDate createdDate,
         List<GroupMemberProfileDto> profiles,
         List<Long> categoryIds) {
-    public static GetGroupsRes of(GroupSummaryDto dto, List<GroupMemberProfileDto> profiles, List<GroupCategoryDto> categoryIds) {
+    public static GetGroupsRes of(
+            GroupSummaryDto dto, List<GroupMemberProfileMappingDto> rawProfiles, List<GroupCategoryDto> categoryIds) {
         return new GetGroupsRes(
                 dto.id(),
                 dto.name(),
@@ -23,7 +25,9 @@ public record GetGroupsRes(
                 dto.open(),
                 dto.approvalRequired(),
                 dto.createdDate(),
-                profiles,
+                rawProfiles.stream()
+                        .map(rp -> new GroupMemberProfileDto(rp.userId(), rp.nickname(), rp.imageUrl(), rp.role()))
+                        .toList(),
                 categoryIds.stream().map(GroupCategoryDto::categoryId).toList());
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/dto/GetGroupsRes.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GetGroupsRes.java
@@ -1,6 +1,8 @@
 package com.studypals.domain.groupManage.dto;
 
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import java.time.LocalDate;
+import java.util.List;
 
 public record GetGroupsRes(
         Long groupId,
@@ -9,8 +11,10 @@ public record GetGroupsRes(
         String chatRoomId,
         boolean isOpen,
         boolean isApprovalRequired,
-        LocalDate createdDate) {
-    public static GetGroupsRes from(GroupSummaryDto dto) {
+        LocalDate createdDate,
+        List<GroupMemberProfileDto> profiles,
+        List<Long> categoryIds) {
+    public static GetGroupsRes of(GroupSummaryDto dto, List<GroupMemberProfileDto> profiles, List<GroupCategoryDto> categoryIds) {
         return new GetGroupsRes(
                 dto.id(),
                 dto.name(),
@@ -18,6 +22,8 @@ public record GetGroupsRes(
                 dto.chatRoomId(),
                 dto.open(),
                 dto.approvalRequired(),
-                dto.createdDate());
+                dto.createdDate(),
+                profiles,
+                categoryIds.stream().map(GroupCategoryDto::categoryId).toList());
     }
 }

--- a/src/main/java/com/studypals/domain/groupManage/dto/GetGroupsRes.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GetGroupsRes.java
@@ -9,11 +9,12 @@ public record GetGroupsRes(
         Long groupId,
         String groupName,
         String groupTag,
+        int memberCount,
         String chatRoomId,
         boolean isOpen,
         boolean isApprovalRequired,
         LocalDate createdDate,
-        List<GroupMemberProfileDto> profiles,
+        List<GroupMemberProfileImageDto> profiles,
         List<Long> categoryIds) {
     public static GetGroupsRes of(
             GroupSummaryDto dto, List<GroupMemberProfileMappingDto> rawProfiles, List<GroupCategoryDto> categoryIds) {
@@ -21,12 +22,13 @@ public record GetGroupsRes(
                 dto.id(),
                 dto.name(),
                 dto.tag(),
+                dto.memberCount(),
                 dto.chatRoomId(),
                 dto.open(),
                 dto.approvalRequired(),
                 dto.createdDate(),
                 rawProfiles.stream()
-                        .map(rp -> new GroupMemberProfileDto(rp.userId(), rp.nickname(), rp.imageUrl(), rp.role()))
+                        .map(rp -> new GroupMemberProfileImageDto(rp.imageUrl(), rp.role()))
                         .toList(),
                 categoryIds.stream().map(GroupCategoryDto::categoryId).toList());
     }

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupMemberProfileMappingDto.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupMemberProfileMappingDto.java
@@ -1,6 +1,14 @@
 package com.studypals.domain.groupManage.dto;
 
 import com.studypals.domain.groupManage.entity.GroupRole;
+import com.studypals.domain.groupManage.service.GroupService;
 
+/**
+ * {@link GroupService} 의 getGroups() 메서드에서 [groupId : 그룹에 속한 유저들 정보] Map을 만들기 위해 사용합니다.
+ *
+ * @author sleepyhoon
+ * @see GroupService
+ * @since 2025-12-21
+ */
 public record GroupMemberProfileMappingDto(
         Long groupId, Long userId, String nickname, String imageUrl, GroupRole role) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupMemberProfileMappingDto.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupMemberProfileMappingDto.java
@@ -11,4 +11,4 @@ import com.studypals.domain.groupManage.service.GroupService;
  * @since 2025-12-21
  */
 public record GroupMemberProfileMappingDto(
-        Long groupId, Long userId, String nickname, String imageUrl, GroupRole role) {}
+        Long groupId, String imageUrl, GroupRole role) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupMemberProfileMappingDto.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupMemberProfileMappingDto.java
@@ -1,0 +1,6 @@
+package com.studypals.domain.groupManage.dto;
+
+import com.studypals.domain.groupManage.entity.GroupRole;
+
+public record GroupMemberProfileMappingDto(
+        Long groupId, Long userId, String nickname, String imageUrl, GroupRole role) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupSummaryDto.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupSummaryDto.java
@@ -6,6 +6,7 @@ public record GroupSummaryDto(
         Long id,
         String name,
         String tag,
+        int memberCount,
         String chatRoomId,
         boolean open,
         boolean approvalRequired,

--- a/src/main/java/com/studypals/domain/groupManage/entity/GroupConst.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/GroupConst.java
@@ -1,0 +1,23 @@
+package com.studypals.domain.groupManage.entity;
+
+import com.studypals.domain.groupManage.service.GroupEntryService;
+import lombok.Getter;
+
+/**
+ * group 그룹 관련 상수를 담는 enum 클래스입니다.
+ *
+ *
+ * @author sleepyhoon
+ * @since 2025-12-22
+ */
+@Getter
+public enum GroupConst {
+    /** 그룹 요약 정보 조회 시 포함되는 그룹 멤버 수 */
+    GROUP_SUMMARY_MEMBER_COUNT(4),
+    ;
+
+    private final int value;
+    GroupConst(int value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.groupManage.service;
 
+import com.studypals.domain.groupManage.entity.GroupConst;
 import java.util.List;
 
 import org.springframework.data.domain.Slice;
@@ -39,9 +40,6 @@ import com.studypals.global.responses.CursorResponse;
 @Service
 @RequiredArgsConstructor
 public class GroupEntryServiceImpl implements GroupEntryService {
-    /** 그룹 요약 정보 조회 시 포함되는 그룹 멤버 수 */
-    private static final int GROUP_SUMMARY_MEMBER_COUNT = 5;
-
     private final MemberReader memberReader;
     private final GroupReader groupReader;
     private final GroupMemberWriter groupMemberWriter;
@@ -69,7 +67,7 @@ public class GroupEntryServiceImpl implements GroupEntryService {
         Long groupId = entryCodeManager.getGroupId(entryCode);
         Group group = groupReader.getById(groupId);
         List<GroupMemberProfileDto> profiles =
-                groupMemberReader.getTopNMemberProfiles(group, GROUP_SUMMARY_MEMBER_COUNT);
+                groupMemberReader.getTopNMemberProfiles(group, GroupConst.GROUP_SUMMARY_MEMBER_COUNT.getValue());
 
         return GroupSummaryRes.of(group, profiles);
     }

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.groupManage.service;
 
+import com.studypals.domain.groupManage.entity.GroupConst;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,8 @@ public class GroupServiceImpl implements GroupService {
         List<Long> groupIds = groups.stream().map(GroupSummaryDto::id).toList();
 
         // 각 그룹에 속한 멤버들 프로필, 역할 조회하기
-        List<GroupMemberProfileMappingDto> profileImages = groupMemberReader.getAllMemberProfileImages(groupIds);
+        List<GroupMemberProfileMappingDto> profileImages = groupMemberReader.getTopNMemberProfileImages(groupIds,
+                GroupConst.GROUP_SUMMARY_MEMBER_COUNT.getValue());
 
         // 그룹id : 속한 멤버들
         Map<Long, List<GroupMemberProfileMappingDto>> membersMap =

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -1,13 +1,10 @@
 package com.studypals.domain.groupManage.service;
 
-import com.studypals.domain.studyManage.dto.GroupCategoryDto;
-import com.studypals.domain.studyManage.entity.StudyType;
-import com.studypals.domain.studyManage.worker.StudyCategoryReader;
 import java.util.Collections;
 import java.util.List;
-
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +19,9 @@ import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.worker.*;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.memberManage.worker.MemberReader;
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
+import com.studypals.domain.studyManage.entity.StudyType;
+import com.studypals.domain.studyManage.worker.StudyCategoryReader;
 
 /**
  * group service 의 구현 클래스입니다.
@@ -83,27 +83,25 @@ public class GroupServiceImpl implements GroupService {
         List<Long> groupIds = groups.stream().map(GroupSummaryDto::id).toList();
 
         // 각 그룹에 속한 멤버들 프로필, 역할 조회하기
-        List<GroupMemberProfileDto> profileImages = groupMemberReader.getAllMemberProfileImages(
-                groupIds);
+        List<GroupMemberProfileMappingDto> profileImages = groupMemberReader.getAllMemberProfileImages(groupIds);
 
         // 그룹id : 속한 멤버들
-        Map<Long, List<GroupMemberProfileDto>> membersMap = profileImages.stream()
-                .collect(Collectors.groupingBy(GroupMemberProfileDto::id));
+        Map<Long, List<GroupMemberProfileMappingDto>> membersMap =
+                profileImages.stream().collect(Collectors.groupingBy(GroupMemberProfileMappingDto::groupId));
 
         // 각 그룹이 가지고 있는 카테고리 조회하기
-        List<GroupCategoryDto> groupCategories = studyCategoryReader.findByStudyTypeAndTypeId(
-                StudyType.GROUP, groupIds);
+        List<GroupCategoryDto> groupCategories =
+                studyCategoryReader.findByStudyTypeAndTypeId(StudyType.GROUP, groupIds);
 
         // 그룹id : 속한 카테고리들
-        Map<Long, List<GroupCategoryDto>> categoriesMap = groupCategories.stream()
-                .collect(Collectors.groupingBy(GroupCategoryDto::groupId));
+        Map<Long, List<GroupCategoryDto>> categoriesMap =
+                groupCategories.stream().collect(Collectors.groupingBy(GroupCategoryDto::groupId));
 
         return groups.stream()
                 .map(group -> GetGroupsRes.of(
                         group,
                         membersMap.getOrDefault(group.id(), Collections.emptyList()),
-                        categoriesMap.getOrDefault(group.id(), Collections.emptyList())
-                ))
+                        categoriesMap.getOrDefault(group.id(), Collections.emptyList())))
                 .toList();
     }
 

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupServiceImpl.java
@@ -1,7 +1,13 @@
 package com.studypals.domain.groupManage.service;
 
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
+import com.studypals.domain.studyManage.entity.StudyType;
+import com.studypals.domain.studyManage.worker.StudyCategoryReader;
+import java.util.Collections;
 import java.util.List;
 
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,9 +49,8 @@ public class GroupServiceImpl implements GroupService {
     private final GroupAuthorityValidator validator;
     private final GroupMapper groupMapper;
     private final GroupGoalCalculator groupGoalCalculator;
-
-    // chat room worker class
     private final ChatRoomWriter chatRoomWriter;
+    private final StudyCategoryReader studyCategoryReader;
 
     @Override
     public List<GetGroupTagRes> getGroupTags() {
@@ -75,7 +80,31 @@ public class GroupServiceImpl implements GroupService {
         // jwt filter 에서 주입한 userId이므로 DB에 존재하는지 체크하지 않음
         List<GroupSummaryDto> groups = groupMemberReader.getGroups(userId);
 
-        return groups.stream().map(GetGroupsRes::from).toList();
+        List<Long> groupIds = groups.stream().map(GroupSummaryDto::id).toList();
+
+        // 각 그룹에 속한 멤버들 프로필, 역할 조회하기
+        List<GroupMemberProfileDto> profileImages = groupMemberReader.getAllMemberProfileImages(
+                groupIds);
+
+        // 그룹id : 속한 멤버들
+        Map<Long, List<GroupMemberProfileDto>> membersMap = profileImages.stream()
+                .collect(Collectors.groupingBy(GroupMemberProfileDto::id));
+
+        // 각 그룹이 가지고 있는 카테고리 조회하기
+        List<GroupCategoryDto> groupCategories = studyCategoryReader.findByStudyTypeAndTypeId(
+                StudyType.GROUP, groupIds);
+
+        // 그룹id : 속한 카테고리들
+        Map<Long, List<GroupCategoryDto>> categoriesMap = groupCategories.stream()
+                .collect(Collectors.groupingBy(GroupCategoryDto::groupId));
+
+        return groups.stream()
+                .map(group -> GetGroupsRes.of(
+                        group,
+                        membersMap.getOrDefault(group.id(), Collections.emptyList()),
+                        categoriesMap.getOrDefault(group.id(), Collections.emptyList())
+                ))
+                .toList();
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
@@ -1,12 +1,12 @@
 package com.studypals.domain.groupManage.worker;
 
-import com.studypals.domain.groupManage.dto.GroupMemberProfileImageDto;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.groupManage.dao.GroupMemberRepository;
 import com.studypals.domain.groupManage.dto.GroupMemberProfileDto;
+import com.studypals.domain.groupManage.dto.GroupMemberProfileMappingDto;
 import com.studypals.domain.groupManage.dto.GroupSummaryDto;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.global.annotations.Worker;
@@ -40,7 +40,7 @@ public class GroupMemberReader {
         return groupMemberRepository.findAllMemberProfiles(group.getId());
     }
 
-    public List<GroupMemberProfileDto> getAllMemberProfileImages(List<Long> groupIds) {
+    public List<GroupMemberProfileMappingDto> getAllMemberProfileImages(List<Long> groupIds) {
         return groupMemberRepository.findAllMembersInGroupIds(groupIds);
     }
 

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
@@ -41,7 +41,7 @@ public class GroupMemberReader {
     }
 
     public List<GroupMemberProfileMappingDto> getTopNMemberProfileImages(List<Long> groupIds, int limit) {
-        return groupMemberRepository.findAllMembersInGroupIds(groupIds, limit);
+        return groupMemberRepository.findTopNMemberInGroupIds(groupIds, limit);
     }
 
     public List<GroupSummaryDto> getGroups(Long userId) {

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
@@ -40,8 +40,8 @@ public class GroupMemberReader {
         return groupMemberRepository.findAllMemberProfiles(group.getId());
     }
 
-    public List<GroupMemberProfileMappingDto> getAllMemberProfileImages(List<Long> groupIds) {
-        return groupMemberRepository.findAllMembersInGroupIds(groupIds);
+    public List<GroupMemberProfileMappingDto> getTopNMemberProfileImages(List<Long> groupIds, int limit) {
+        return groupMemberRepository.findAllMembersInGroupIds(groupIds, limit);
     }
 
     public List<GroupSummaryDto> getGroups(Long userId) {

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupMemberReader.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.groupManage.worker;
 
+import com.studypals.domain.groupManage.dto.GroupMemberProfileImageDto;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,10 @@ public class GroupMemberReader {
 
     public List<GroupMemberProfileDto> getAllMemberProfiles(Group group) {
         return groupMemberRepository.findAllMemberProfiles(group.getId());
+    }
+
+    public List<GroupMemberProfileDto> getAllMemberProfileImages(List<Long> groupIds) {
+        return groupMemberRepository.findAllMembersInGroupIds(groupIds);
     }
 
     public List<GroupSummaryDto> getGroups(Long userId) {

--- a/src/main/java/com/studypals/domain/studyManage/dao/StudyCategoryRepository.java
+++ b/src/main/java/com/studypals/domain/studyManage/dao/StudyCategoryRepository.java
@@ -1,6 +1,5 @@
 package com.studypals.domain.studyManage.dao;
 
-import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import com.studypals.domain.studyManage.entity.StudyCategory;
 import com.studypals.domain.studyManage.entity.StudyType;
 
@@ -30,10 +30,13 @@ public interface StudyCategoryRepository extends JpaRepository<StudyCategory, Lo
 
     List<StudyCategory> findByStudyTypeAndTypeId(StudyType studyType, Long typeId);
 
-    @Query(value = """
+    @Query(
+            value =
+                    """
         SELECT new com.studypals.domain.studyManage.dto.GroupCategoryDto(sc.typeId, sc.id)
         FROM study_category sc
         WHERE sc.studyType =:studyType AND sc.typeId IN :typeIds
     """)
-    List<GroupCategoryDto> findByStudyTypeAndTypeIds(@Param("studyType") StudyType studyType, @Param("typeIds") List<Long> typeIds);
+    List<GroupCategoryDto> findByStudyTypeAndTypeIds(
+            @Param("studyType") StudyType studyType, @Param("typeIds") List<Long> typeIds);
 }

--- a/src/main/java/com/studypals/domain/studyManage/dao/StudyCategoryRepository.java
+++ b/src/main/java/com/studypals/domain/studyManage/dao/StudyCategoryRepository.java
@@ -1,8 +1,11 @@
 package com.studypals.domain.studyManage.dao;
 
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.studypals.domain.studyManage.entity.StudyCategory;
@@ -26,4 +29,11 @@ import com.studypals.domain.studyManage.entity.StudyType;
 public interface StudyCategoryRepository extends JpaRepository<StudyCategory, Long>, StudyCategoryCustomRepository {
 
     List<StudyCategory> findByStudyTypeAndTypeId(StudyType studyType, Long typeId);
+
+    @Query(value = """
+        SELECT new com.studypals.domain.studyManage.dto.GroupCategoryDto(sc.typeId, sc.id)
+        FROM study_category sc
+        WHERE sc.studyType =:studyType AND sc.typeId IN :typeIds
+    """)
+    List<GroupCategoryDto> findByStudyTypeAndTypeIds(@Param("studyType") StudyType studyType, @Param("typeIds") List<Long> typeIds);
 }

--- a/src/main/java/com/studypals/domain/studyManage/dto/GroupCategoryDto.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GroupCategoryDto.java
@@ -21,6 +21,4 @@ package com.studypals.domain.studyManage.dto;
  * @see
  * @since 2025-12-21
  */
-public record GroupCategoryDto(Long groupId, Long categoryId) {
-
-}
+public record GroupCategoryDto(Long groupId, Long categoryId) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GroupCategoryDto.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GroupCategoryDto.java
@@ -1,24 +1,12 @@
 package com.studypals.domain.studyManage.dto;
 
+import com.studypals.domain.groupManage.service.GroupService;
+
 /**
- * 코드에 대한 전체적인 역할을 적습니다.
- * <p>
- * 코드에 대한 작동 원리 등을 적습니다.
+ * {@link GroupService} 의 getGroups() 메서드에서 [groupId : 그룹이 가지는 카테고리 id 리스트] Map을 만들기 위해 사용합니다.
  *
- * <p><b>상속 정보:</b><br>
- * 상속 정보를 적습니다.
- *
- * <p><b>주요 생성자:</b><br>
- * {@code ExampleClass(String example)}  <br> 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
- *
- * <p><b>빈 관리:</b><br>
- * 필요 시 빈 관리에 대한 내용을 적습니다.
- *
- * <p><b>외부 모듈:</b><br>
- * 필요 시 외부 모듈에 대한 내용을 적습니다.
- *
- * @author My
- * @see
+ * @author sleepyhoon
+ * @see GroupService
  * @since 2025-12-21
  */
 public record GroupCategoryDto(Long groupId, Long categoryId) {}

--- a/src/main/java/com/studypals/domain/studyManage/dto/GroupCategoryDto.java
+++ b/src/main/java/com/studypals/domain/studyManage/dto/GroupCategoryDto.java
@@ -1,0 +1,26 @@
+package com.studypals.domain.studyManage.dto;
+
+/**
+ * 코드에 대한 전체적인 역할을 적습니다.
+ * <p>
+ * 코드에 대한 작동 원리 등을 적습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 상속 정보를 적습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code ExampleClass(String example)}  <br> 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
+ *
+ * <p><b>빈 관리:</b><br>
+ * 필요 시 빈 관리에 대한 내용을 적습니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ *
+ * @author My
+ * @see
+ * @since 2025-12-21
+ */
+public record GroupCategoryDto(Long groupId, Long categoryId) {
+
+}

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
@@ -1,12 +1,12 @@
 package com.studypals.domain.studyManage.worker;
 
-import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import java.util.List;
 import java.util.Map;
 
 import lombok.RequiredArgsConstructor;
 
 import com.studypals.domain.studyManage.dao.StudyCategoryRepository;
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import com.studypals.domain.studyManage.entity.StudyCategory;
 import com.studypals.domain.studyManage.entity.StudyType;
 import com.studypals.global.annotations.Worker;

--- a/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
+++ b/src/main/java/com/studypals/domain/studyManage/worker/StudyCategoryReader.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.studyManage.worker;
 
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
 import java.util.List;
 import java.util.Map;
 
@@ -59,5 +60,15 @@ public class StudyCategoryReader {
      */
     public List<StudyCategory> findByStudyTypeAndTypeId(StudyType type, Long typeId) {
         return studyCategoryRepository.findByStudyTypeAndTypeId(type, typeId);
+    }
+
+    /**
+     * type 과 typeId 리스트 안에 존재하는 id에 해당하는 StudyCategory 의 List로 반환합니다. 빈 리스트가 반환될 수도 있습니다.
+     * @param type 검색하고자 할 StudyType
+     * @param typeIds 검색하고자 할 StudyType 에 따른 typeId 리스트
+     * @return
+     */
+    public List<GroupCategoryDto> findByStudyTypeAndTypeId(StudyType type, List<Long> typeIds) {
+        return studyCategoryRepository.findByStudyTypeAndTypeIds(type, typeIds);
     }
 }

--- a/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.studypals.domain.groupManage.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.studypals.domain.groupManage.dto.GroupMemberProfileMappingDto;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -69,5 +70,57 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
 
         // then
         assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    void findAllMemberProfiles_success() {
+        // given
+        Member m1 = insertMember("user1", "리더");
+        Member m2 = insertMember("user2", "멤버");
+        ChatRoom chatRoom = insertChatRoom("chat1");
+        Group group = insertGroup(chatRoom);
+
+        insertGroupMember(group, m2, GroupRole.MEMBER); // 나중에 가입한 일반 멤버
+        insertGroupMember(group, m1, GroupRole.LEADER); // 리더
+
+        // when
+        List<GroupMemberProfileDto> result = groupMemberRepository.findAllMemberProfiles(group.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).nickname()).isEqualTo("리더"); // 리더가 우선순위로 나와야 함
+        assertThat(result.get(0).role()).isEqualTo(GroupRole.LEADER);
+    }
+
+    @Test
+    void findAllMembersInGroupIds_success() {
+        // given
+        Member m1 = insertMember("user1", "그룹1리더");
+        Member m2 = insertMember("user2", "그룹2리더");
+
+        ChatRoom cr1 = insertChatRoom("chat1");
+        ChatRoom cr2 = insertChatRoom("chat2");
+        Group g1 = insertGroup(cr1);
+        Group g2 = insertGroup(cr2);
+
+        insertGroupMember(g1, m1, GroupRole.LEADER);
+        insertGroupMember(g2, m2, GroupRole.LEADER);
+
+        List<Long> groupIds = List.of(g1.getId(), g2.getId());
+
+        // when
+        List<GroupMemberProfileMappingDto> result = groupMemberRepository.findAllMembersInGroupIds(groupIds);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        // MappingDto에 groupId가 정확히 매칭되었는지 검증 (가장 중요)
+        GroupMemberProfileMappingDto mapping1 = result.stream()
+                .filter(r -> r.groupId().equals(g1.getId())).findFirst().get();
+        assertThat(mapping1.nickname()).isEqualTo("그룹1리더");
+
+        GroupMemberProfileMappingDto mapping2 = result.stream()
+                .filter(r -> r.groupId().equals(g2.getId())).findFirst().get();
+        assertThat(mapping2.nickname()).isEqualTo("그룹2리더");
     }
 }

--- a/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
@@ -2,7 +2,6 @@ package com.studypals.domain.groupManage.dao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.studypals.domain.groupManage.dto.GroupMemberProfileMappingDto;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -12,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.studypals.domain.chatManage.entity.ChatRoom;
 import com.studypals.domain.groupManage.dto.GroupMemberProfileDto;
+import com.studypals.domain.groupManage.dto.GroupMemberProfileMappingDto;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupMember;
 import com.studypals.domain.groupManage.entity.GroupRole;
@@ -116,11 +116,15 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
 
         // MappingDto에 groupId가 정확히 매칭되었는지 검증 (가장 중요)
         GroupMemberProfileMappingDto mapping1 = result.stream()
-                .filter(r -> r.groupId().equals(g1.getId())).findFirst().get();
+                .filter(r -> r.groupId().equals(g1.getId()))
+                .findFirst()
+                .get();
         assertThat(mapping1.nickname()).isEqualTo("그룹1리더");
 
         GroupMemberProfileMappingDto mapping2 = result.stream()
-                .filter(r -> r.groupId().equals(g2.getId())).findFirst().get();
+                .filter(r -> r.groupId().equals(g2.getId()))
+                .findFirst()
+                .get();
         assertThat(mapping2.nickname()).isEqualTo("그룹2리더");
     }
 }

--- a/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
@@ -31,10 +31,10 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
 
     private Group insertGroup(ChatRoom chatRoom) {
         return em.persist(Group.builder()
-                .totalMember(1)
+                .totalMember(2)
                 .name("group")
                 .tag("tag")
-                .totalMember(2)
+                .maxMember(10)
                 .chatRoom(chatRoom)
                 .build());
     }
@@ -95,6 +95,7 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
     @Test
     void findAllMembersInGroupIds_success() {
         // given
+        int limit = 4;
         Member m1 = insertMember("user1", "그룹1리더");
         Member m2 = insertMember("user2", "그룹2리더");
 
@@ -109,7 +110,7 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
         List<Long> groupIds = List.of(g1.getId(), g2.getId());
 
         // when
-        List<GroupMemberProfileMappingDto> result = groupMemberRepository.findAllMembersInGroupIds(groupIds);
+        List<GroupMemberProfileMappingDto> result = groupMemberRepository.findAllMembersInGroupIds(groupIds, limit);
 
         // then
         assertThat(result).hasSize(2);
@@ -119,12 +120,14 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
                 .filter(r -> r.groupId().equals(g1.getId()))
                 .findFirst()
                 .get();
-        assertThat(mapping1.nickname()).isEqualTo("그룹1리더");
+        assertThat(mapping1.groupId()).isEqualTo(g1.getId());
+        assertThat(mapping1.imageUrl()).isEqualTo("imageUrl-url");
 
         GroupMemberProfileMappingDto mapping2 = result.stream()
                 .filter(r -> r.groupId().equals(g2.getId()))
                 .findFirst()
                 .get();
-        assertThat(mapping2.nickname()).isEqualTo("그룹2리더");
+        assertThat(mapping2.groupId()).isEqualTo(g2.getId());
+        assertThat(mapping2.imageUrl()).isEqualTo("imageUrl-url");
     }
 }

--- a/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/dao/GroupMemberRepositoryTest.java
@@ -110,7 +110,7 @@ public class GroupMemberRepositoryTest extends DataJpaSupport {
         List<Long> groupIds = List.of(g1.getId(), g2.getId());
 
         // when
-        List<GroupMemberProfileMappingDto> result = groupMemberRepository.findAllMembersInGroupIds(groupIds, limit);
+        List<GroupMemberProfileMappingDto> result = groupMemberRepository.findTopNMemberInGroupIds(groupIds, limit);
 
         // then
         assertThat(result).hasSize(2);

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
@@ -117,23 +117,25 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                         101L,
                         "알고리즘 코딩 마스터",
                         "취업준비",
+                        10,
                         "chat_algo_01",
                         true,
                         false,
                         LocalDate.of(2025, 12, 1),
-                        List.of(new GroupMemberProfileDto(1L, "코딩왕", "https://exam.com/user1.png", GroupRole.LEADER)),
+                        List.of(new GroupMemberProfileImageDto("https://exam.com/user1.png", GroupRole.LEADER)),
                         List.of(1L, 2L)),
                 new GetGroupsRes(
                         205L,
                         "프론트엔드 리액트 스터디",
                         "프론트개발",
+                        20,
                         "chat_react_fe",
                         false,
                         true,
                         LocalDate.of(2025, 10, 25),
                         List.of(
-                                new GroupMemberProfileDto(2L, "리액트장인", "https://exam.com/user2.png", GroupRole.LEADER),
-                                new GroupMemberProfileDto(3L, "뉴비열공", "https://exam.com/user3.png", GroupRole.MEMBER)),
+                                new GroupMemberProfileImageDto("https://exam.com/user2.png", GroupRole.LEADER),
+                                new GroupMemberProfileImageDto("https://exam.com/user3.png", GroupRole.MEMBER)),
                         List.of(3L, 4L)));
         Response<List<GetGroupsRes>> expected = CommonResponse.success(ResponseCode.GROUP_LIST, list);
 
@@ -155,6 +157,7 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data[].groupId").description("그룹의 고유 ID"),
                                 fieldWithPath("data[].groupName").description("그룹 이름"),
                                 fieldWithPath("data[].groupTag").description("그룹의 태그"),
+                                fieldWithPath("data[].memberCount").description("그룹에 속한 전체 회원 수"),
                                 fieldWithPath("data[].chatRoomId").description("그룹에 연결된 채팅방 ID"),
                                 fieldWithPath("data[].isOpen").description("그룹 공개 여부 (true: 공개, false: 비공개)"),
                                 fieldWithPath("data[].isApprovalRequired")
@@ -162,8 +165,6 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data[].createdDate").description("그룹 생성일"),
 
                                 // 멤버 프로필 정보 상세화
-                                fieldWithPath("data[].profiles[].id").description("멤버의 고유 식별자 ID"),
-                                fieldWithPath("data[].profiles[].nickname").description("멤버의 닉네임"),
                                 fieldWithPath("data[].profiles[].imageUrl").description("멤버의 프로필 이미지 URL"),
                                 fieldWithPath("data[].profiles[].role").description("그룹 내 역할 (LEADER, MEMBER)"),
 

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -118,25 +119,27 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                         "알고리즘 코딩 마스터",
                         "취업준비",
                         "chat_algo_01",
-                        true, // 공개 (isOpen)
-                        false, // 승인 불필요 (isApprovalRequired)
-                        LocalDate.of(2025, 12, 1)),
+                        true,
+                        false,
+                        LocalDate.of(2025, 12, 1),
+                        List.of(new GroupMemberProfileDto(1L, "코딩왕", "https://exam.com/user1.png", GroupRole.LEADER)),
+                        List.of(1L, 2L)
+                ),
                 new GetGroupsRes(
                         205L,
                         "프론트엔드 리액트 스터디",
                         "프론트개발",
                         "chat_react_fe",
-                        false, // 비공개
-                        true, // 승인 필요
-                        LocalDate.of(2025, 10, 25)),
-                new GetGroupsRes(
-                        312L,
-                        "CS 지식 주간 정리",
-                        "전공시험",
-                        "chat_cs_wk",
-                        true, // 공개
-                        true, // 승인 필요
-                        LocalDate.of(2025, 9, 10)));
+                        false,
+                        true,
+                        LocalDate.of(2025, 10, 25),
+                        List.of(
+                                new GroupMemberProfileDto(2L, "리액트장인", "https://exam.com/user2.png", GroupRole.LEADER),
+                                new GroupMemberProfileDto(3L, "뉴비열공", "https://exam.com/user3.png", GroupRole.MEMBER)
+                        ),
+                        List.of(3L, 4L)
+                )
+        );
         Response<List<GetGroupsRes>> expected = CommonResponse.success(ResponseCode.GROUP_LIST, list);
 
         given(groupService.getGroups(any())).willReturn(list);
@@ -149,9 +152,11 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                         httpRequest(),
                         httpResponse(),
                         responseFields(
-                                fieldWithPath("code").description("U02-17"),
-                                fieldWithPath("status").description("응답 상태(예: success or failed"),
+                                fieldWithPath("code").description("응답 코드 (예: U02-17)"),
+                                fieldWithPath("status").description("응답 상태 (예: success)"),
                                 fieldWithPath("message").description("응답 메시지"),
+
+                                // 그룹 기본 정보
                                 fieldWithPath("data[].groupId").description("그룹의 고유 ID"),
                                 fieldWithPath("data[].groupName").description("그룹 이름"),
                                 fieldWithPath("data[].groupTag").description("그룹의 태그"),
@@ -159,7 +164,17 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data[].isOpen").description("그룹 공개 여부 (true: 공개, false: 비공개)"),
                                 fieldWithPath("data[].isApprovalRequired")
                                         .description("그룹 가입 시 승인 필요 여부 (true: 필요, false: 불필요)"),
-                                fieldWithPath("data[].createdDate").description("그룹 생성일"))));
+                                fieldWithPath("data[].createdDate").description("그룹 생성일"),
+
+                                // 멤버 프로필 정보 상세화
+                                fieldWithPath("data[].profiles[].id").description("멤버의 고유 식별자 ID"),
+                                fieldWithPath("data[].profiles[].nickname").description("멤버의 닉네임"),
+                                fieldWithPath("data[].profiles[].imageUrl").description("멤버의 프로필 이미지 URL"),
+                                fieldWithPath("data[].profiles[].role").description("그룹 내 역할 (LEADER, MEMBER)"),
+
+                                // 카테고리 정보
+                                fieldWithPath("data[].categoryIds[]").description("그룹 카테고리 ID 목록")
+                        )));
     }
 
     @Test

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupControllerRestDocsTest.java
@@ -15,7 +15,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -123,8 +122,7 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                         false,
                         LocalDate.of(2025, 12, 1),
                         List.of(new GroupMemberProfileDto(1L, "코딩왕", "https://exam.com/user1.png", GroupRole.LEADER)),
-                        List.of(1L, 2L)
-                ),
+                        List.of(1L, 2L)),
                 new GetGroupsRes(
                         205L,
                         "프론트엔드 리액트 스터디",
@@ -135,11 +133,8 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                         LocalDate.of(2025, 10, 25),
                         List.of(
                                 new GroupMemberProfileDto(2L, "리액트장인", "https://exam.com/user2.png", GroupRole.LEADER),
-                                new GroupMemberProfileDto(3L, "뉴비열공", "https://exam.com/user3.png", GroupRole.MEMBER)
-                        ),
-                        List.of(3L, 4L)
-                )
-        );
+                                new GroupMemberProfileDto(3L, "뉴비열공", "https://exam.com/user3.png", GroupRole.MEMBER)),
+                        List.of(3L, 4L)));
         Response<List<GetGroupsRes>> expected = CommonResponse.success(ResponseCode.GROUP_LIST, list);
 
         given(groupService.getGroups(any())).willReturn(list);
@@ -173,8 +168,7 @@ public class GroupControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data[].profiles[].role").description("그룹 내 역할 (LEADER, MEMBER)"),
 
                                 // 카테고리 정보
-                                fieldWithPath("data[].categoryIds[]").description("그룹 카테고리 ID 목록")
-                        )));
+                                fieldWithPath("data[].categoryIds[]").description("그룹 카테고리 ID 목록"))));
     }
 
     @Test

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
@@ -6,9 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 
-import com.studypals.domain.studyManage.dto.GroupCategoryDto;
-import com.studypals.domain.studyManage.entity.StudyType;
-import com.studypals.domain.studyManage.worker.StudyCategoryReader;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -28,6 +25,9 @@ import com.studypals.domain.groupManage.entity.GroupTag;
 import com.studypals.domain.groupManage.worker.*;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.memberManage.worker.MemberReader;
+import com.studypals.domain.studyManage.dto.GroupCategoryDto;
+import com.studypals.domain.studyManage.entity.StudyType;
+import com.studypals.domain.studyManage.worker.StudyCategoryReader;
 import com.studypals.global.exceptions.errorCode.GroupErrorCode;
 import com.studypals.global.exceptions.exception.GroupException;
 
@@ -160,29 +160,26 @@ public class GroupServiceTest {
         // 1. Given: 그룹 요약 데이터 준비
         Long userId = 1L;
         List<GroupSummaryDto> groups = List.of(
-                new GroupSummaryDto(101L, "CS 전공 지식 뿌시기", "취업준비", "chat_cs001", true, false, LocalDate.of(2025, 11, 15)),
-                new GroupSummaryDto(205L, "자바 스터디 (Spring Boot)", "백엔드개발", "chat_java05", false, true, LocalDate.of(2025, 10, 20))
-        );
+                new GroupSummaryDto(
+                        101L, "CS 전공 지식 뿌시기", "취업준비", "chat_cs001", true, false, LocalDate.of(2025, 11, 15)),
+                new GroupSummaryDto(
+                        205L, "자바 스터디 (Spring Boot)", "백엔드개발", "chat_java05", false, true, LocalDate.of(2025, 10, 20)));
         List<Long> groupIds = List.of(101L, 205L);
 
         given(groupMemberReader.getGroups(userId)).willReturn(groups);
 
         // 2. Given: 멤버 프로필 데이터 준비 (groupId가 포함된 DTO여야 함)
-        List<GroupMemberProfileDto> profiles = List.of(
-                new GroupMemberProfileDto(101L, "코딩왕", "https://img.com/1", GroupRole.LEADER),
-                new GroupMemberProfileDto(205L,  "백엔드곰", "https://img.com/2", GroupRole.MEMBER)
-        );
-        // 서비스 로직에서 ProfileDto::id로 groupingBy를 하므로,
-        // 여기서 id가 groupId 역할을 하거나 서비스 로직을 GroupMemberProfileDto::groupId로 수정해야 함
+        List<GroupMemberProfileMappingDto> profiles = List.of(
+                new GroupMemberProfileMappingDto(101L, 1L, "코딩왕", "https://img.com/1", GroupRole.LEADER),
+                new GroupMemberProfileMappingDto(205L, 2L, "백엔드곰", "https://img.com/2", GroupRole.MEMBER));
+
         given(groupMemberReader.getAllMemberProfileImages(groupIds)).willReturn(profiles);
 
         // 3. Given: 카테고리 데이터 준비
-        List<GroupCategoryDto> categories = List.of(
-                new GroupCategoryDto(101L, 1L),
-                new GroupCategoryDto(101L, 2L),
-                new GroupCategoryDto(205L, 3L)
-        );
-        given(studyCategoryReader.findByStudyTypeAndTypeId(StudyType.GROUP, groupIds)).willReturn(categories);
+        List<GroupCategoryDto> categories =
+                List.of(new GroupCategoryDto(101L, 1L), new GroupCategoryDto(101L, 2L), new GroupCategoryDto(205L, 3L));
+        given(studyCategoryReader.findByStudyTypeAndTypeId(StudyType.GROUP, groupIds))
+                .willReturn(categories);
 
         // When
         List<GetGroupsRes> result = groupService.getGroups(userId);
@@ -234,7 +231,6 @@ public class GroupServiceTest {
         // 2. GroupTotalGoalDto 생성 (평균 71% 가정: (75 + 100 + 40) / 3 = 71.66... -> 71 (버림))
         GroupTotalGoalDto totalGoals = new GroupTotalGoalDto(categoryGoals, 71);
 
-        // 3. Mocking 설정 변경: List<GroupCategoryGoalDto> -> GroupTotalGoalDto
         given(groupReader.getById(groupId)).willReturn(mockGroup);
         given(groupMemberReader.getAllMemberProfiles(mockGroup)).willReturn(profiles);
         given(groupGoalCalculator.calculateGroupGoals(groupId, profiles)).willReturn(totalGoals);

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupServiceTest.java
@@ -159,21 +159,22 @@ public class GroupServiceTest {
     void getGroups_success() {
         // 1. Given: 그룹 요약 데이터 준비
         Long userId = 1L;
+        int limit = 4;
         List<GroupSummaryDto> groups = List.of(
                 new GroupSummaryDto(
-                        101L, "CS 전공 지식 뿌시기", "취업준비", "chat_cs001", true, false, LocalDate.of(2025, 11, 15)),
+                        101L, "CS 전공 지식 뿌시기", "취업준비", 10,"chat_cs001", true, false, LocalDate.of(2025, 11, 15)),
                 new GroupSummaryDto(
-                        205L, "자바 스터디 (Spring Boot)", "백엔드개발", "chat_java05", false, true, LocalDate.of(2025, 10, 20)));
+                        205L, "자바 스터디 (Spring Boot)", "백엔드개발", 20,"chat_java05", false, true, LocalDate.of(2025, 10, 20)));
         List<Long> groupIds = List.of(101L, 205L);
 
         given(groupMemberReader.getGroups(userId)).willReturn(groups);
 
         // 2. Given: 멤버 프로필 데이터 준비 (groupId가 포함된 DTO여야 함)
         List<GroupMemberProfileMappingDto> profiles = List.of(
-                new GroupMemberProfileMappingDto(101L, 1L, "코딩왕", "https://img.com/1", GroupRole.LEADER),
-                new GroupMemberProfileMappingDto(205L, 2L, "백엔드곰", "https://img.com/2", GroupRole.MEMBER));
+                new GroupMemberProfileMappingDto(101L, "https://img.com/1", GroupRole.LEADER),
+                new GroupMemberProfileMappingDto(205L, "https://img.com/2", GroupRole.MEMBER));
 
-        given(groupMemberReader.getAllMemberProfileImages(groupIds)).willReturn(profiles);
+        given(groupMemberReader.getTopNMemberProfileImages(groupIds, limit)).willReturn(profiles);
 
         // 3. Given: 카테고리 데이터 준비
         List<GroupCategoryDto> categories =
@@ -190,11 +191,13 @@ public class GroupServiceTest {
         // 첫 번째 그룹 검증
         assertThat(result.get(0).groupId()).isEqualTo(101L);
         assertThat(result.get(0).profiles()).hasSize(1);
-        assertThat(result.get(0).profiles().get(0).nickname()).isEqualTo("코딩왕");
+        assertThat(result.get(0).profiles().get(0).role()).isEqualTo(GroupRole.LEADER);
         assertThat(result.get(0).categoryIds()).containsExactlyInAnyOrder(1L, 2L);
 
         // 두 번째 그룹 검증
         assertThat(result.get(1).groupId()).isEqualTo(205L);
+        assertThat(result.get(1).profiles()).hasSize(1);
+        assertThat(result.get(1).profiles().get(0).role()).isEqualTo(GroupRole.MEMBER);
         assertThat(result.get(1).categoryIds()).containsExactly(3L);
     }
 


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #139 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
- 유저가 속한 그룹 리스트 조회할 때 각 그룹에 속한 유저들의 프로필, role을 추가로 전달합니다.
- 또한 각 그룹이 가지고 있는 카테고리 id를 List로 반환합니다.

## ✅ PR Point

<!-- 코드리뷰를 받고 싶은 부분, 새로운 지식을 얻게 된 부분 등등 공유하고 싶은 점을 작성 -->
`GroupServiceImpl` 의 `getGroups` 메서드가 다소 길어졌습니다. 다른 최적화 방법이 있다면 추천 부탁드립니다.

## 😭 어려웠던 점

<!-- 해결하기 어려웠거나 시간이 오래 걸린 부분 작성 -->
