### PR TITLE
[#152][FEATURE] 채팅방 정보 반환 시 userInfos 에 nickname 추가

### DIFF
--- a/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomInfoRes.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/ChatRoomInfoRes.java
@@ -19,5 +19,5 @@ public record ChatRoomInfoRes(
         String roomId, String name, List<UserInfo> userInfos, List<ChatCursorRes> cursor, List<LoggingMessage> logs) {
 
     @Builder
-    public record UserInfo(Long userId, ChatRoomRole role, String imageUrl) {}
+    public record UserInfo(Long userId, String nickname, ChatRoomRole role, String imageUrl) {}
 }

--- a/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatRoomMapper.java
+++ b/src/main/java/com/studypals/domain/chatManage/dto/mapper/ChatRoomMapper.java
@@ -23,6 +23,7 @@ public interface ChatRoomMapper {
      */
     @Mapping(target = "userId", source = "member.id")
     @Mapping(target = "imageUrl", source = "member.imageUrl")
+    @Mapping(target = "nickname", source = "member.nickname")
     ChatRoomInfoRes.UserInfo toDto(ChatRoomMember entity);
 
     /**

--- a/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/restDocsTest/ChatRoomControllerRestDocsTest.java
@@ -112,6 +112,7 @@ class ChatRoomControllerRestDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.userInfos[].userId").description("유저 ID"),
                                 fieldWithPath("data.userInfos[].role").description("유저 역할 (ADMIN | MANAGER | MEMBER)"),
                                 fieldWithPath("data.userInfos[].imageUrl").description("유저 프로필 이미지 URL"),
+                                fieldWithPath("data.userInfos[].nickname").description("유저 닉네임"),
                                 fieldWithPath("data.cursor[].userId").description("해당 커서가 가리키는 유저 ID"),
                                 fieldWithPath("data.cursor[].chatId").description("해당 유저가 마지막으로 읽은 채팅 ID"),
                                 fieldWithPath("data.logs[].id").description("채팅 ID"),

--- a/src/test/java/com/studypals/domain/chatManage/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/studypals/domain/chatManage/service/ChatRoomServiceTest.java
@@ -92,7 +92,7 @@ class ChatRoomServiceTest {
         given(mockMember1.getId()).willReturn(2L);
 
         given(chatRoomMapper.toDto(any()))
-                .willReturn(new ChatRoomInfoRes.UserInfo(userId, ChatRoomRole.MEMBER, "image"));
+                .willReturn(new ChatRoomInfoRes.UserInfo(userId, "nickname", ChatRoomRole.MEMBER, "image"));
 
         given(mockMember1.getId()).willReturn(userId);
         given(chatRoomReader.getCachedCursor(chatRoomId)).willReturn(u);


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #152

## ✨ 구현 기능 명세

채팅방 정보 요청 시 참여자 리스트에 각 유저의 nickname 을 같이 반환하도록 수정

테스트 및 rest docs 를 통한 문서 수정
