### PR TITLE
[#158][REFACTOR] 그룹 초대코드 생성 시 이미 존재하는 경우 이를 반환

### DIFF
--- a/src/asciidoc/api/group.adoc
+++ b/src/asciidoc/api/group.adoc
@@ -36,10 +36,10 @@
 
 == ✨ API 문서
 
-=== 그룹 가입/탈퇴/관리 API
+=== 1. 그룹 생성/탈퇴/관리 API
 ''''
 
-==== 1. 그룹 태그 불러오기
+==== 1-1. 그룹 태그 불러오기
 
 *Description* +
 
@@ -61,7 +61,7 @@ include::{snippets}/group-controller-rest-docs-test/get-group-tags_success/http-
 include::{snippets}/group-controller-rest-docs-test/get-group-tags_success/response-fields.adoc[]
 include::{snippets}/group-controller-rest-docs-test/get-group-tags_success/http-response.adoc[]
 
-==== 2. 그룹 생성
+==== 1-2. 그룹 생성
 
 *Description* +
 
@@ -83,9 +83,9 @@ include::{snippets}/group-controller-rest-docs-test/create-group_success/http-re
 include::{snippets}/group-controller-rest-docs-test/create-group_success/response-headers.adoc[]
 include::{snippets}/group-controller-rest-docs-test/create-group_success/http-response.adoc[]
 
-=== 그룹 가입 관련 API
+=== 2. 그룹 가입 관련 API
 
-==== 1. 초대 코드 생성
+==== 2-1. 초대 코드 생성
 
 *Description* +
 
@@ -107,7 +107,39 @@ include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_su
 include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_success/response-fields.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_success/http-response.adoc[]
 
-==== 2. 유저가 속한 그룹 조회
+
+==== 2-2. 초대 코드 만료 시간 설정
+
+*Description* +
+
+'''
+
+그룹 초대 코드 만료 날짜를 설정합니다.
+
+기본적으로 사용자는 모두 "1일"의 만료 기한을 가지는 초대 코드를 가져올 수 있으며, 요청 시마다 만료 기한이 갱신됩니다. 다만, 3일, 7일 단위
+등으로 초대 코드를 생성하고 싶은 사용자를 위해 일종의 옵션으로서 존재하는 API 입니다.
+
+해당 API 는 이미 만들어진 코드가 있을 때, 해당 코드의 만료 기한을 연장하는 API 입니다. 따라서 클라이언트는 먼저 1일 짜리 초대
+코드를 먼저 생성한 뒤, 해당 API 를 사용해 만료 기한을 추가로 설정하도록 해야 합니다.
+
+*Request* +
+
+'''
+
+include::{snippets}/group-entry-controller-rest-docs-test/increase-code-expire_success/http-request.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/increase-code-expire_success/path-parameters.adoc[]
+include::{snippets}/group-entry-controller-rest-docs-test/increase-code-expire_success/request-fields.adoc[]
+
+
+*Response* +
+
+'''
+include::{snippets}/group-entry-controller-rest-docs-test/increase-code-expire_success/http-response.adoc[]
+
+
+
+
+==== 2-3. 유저가 속한 그룹 조회
 
 *Description* +
 
@@ -128,7 +160,7 @@ include::{snippets}/group-controller-rest-docs-test/get-groups_success/http-requ
 include::{snippets}/group-controller-rest-docs-test/get-groups_success/http-response.adoc[]
 include::{snippets}/group-controller-rest-docs-test/get-groups_success/response-fields.adoc[]
 
-==== 3. 그룹 상세 조회
+==== 2-4. 그룹 상세 조회
 
 *Description* +
 
@@ -148,7 +180,7 @@ include::{snippets}/group-controller-rest-docs-test/get-group-detail_success/htt
 include::{snippets}/group-controller-rest-docs-test/get-group-detail_success/http-response.adoc[]
 include::{snippets}/group-controller-rest-docs-test/get-group-detail_success/response-fields.adoc[]
 
-==== 4. 그룹 대표 정보 조회
+==== 2-5. 그룹 대표 정보 조회
 
 *Description* +
 
@@ -173,7 +205,7 @@ include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_succ
 include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_success/http-response.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/get-group-summary_success/response-fields.adoc[]
 
-==== 5. 그룹 가입
+==== 2-6. 그룹 가입
 
 *Description* +
 
@@ -196,7 +228,7 @@ include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/req
 include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/http-response.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/join-group_success/response-headers.adoc[]
 
-==== 6. 그룹 가입 요청
+==== 2-7. 그룹 가입 요청
 
 *Description* +
 
@@ -219,7 +251,7 @@ include::{snippets}/group-entry-controller-rest-docs-test/request-participant_su
 include::{snippets}/group-entry-controller-rest-docs-test/request-participant_success/http-response.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/request-participant_success/response-headers.adoc[]
 
-==== 7. 그룹 가입 요청 조회
+==== 2-8. 그룹 가입 요청 조회
 
 *Description* +
 
@@ -242,7 +274,7 @@ include::{snippets}/group-entry-controller-rest-docs-test/get-entry-requests_suc
 include::{snippets}/group-entry-controller-rest-docs-test/get-entry-requests_success/http-response.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/get-entry-requests_success/response-fields.adoc[]
 
-==== 8. 그룹 가입 요청 승인
+==== 2-9. 그룹 가입 요청 승인
 
 *Description*
 
@@ -263,7 +295,7 @@ include::{snippets}/group-entry-controller-rest-docs-test/accept-entry-request_s
 include::{snippets}/group-entry-controller-rest-docs-test/accept-entry-request_success/http-response.adoc[]
 include::{snippets}/group-entry-controller-rest-docs-test/accept-entry-request_success/response-headers.adoc[]
 
-==== 9. 그룹 가입 요청 거절
+==== 2-10. 그룹 가입 요청 거절
 
 *Description*
 
@@ -283,10 +315,10 @@ include::{snippets}/group-entry-controller-rest-docs-test/refuse-entry-request_s
 '''
 include::{snippets}/group-entry-controller-rest-docs-test/refuse-entry-request_success/http-response.adoc[]
 
-=== 그룹 스터디 조회/생성/관리 API
+=== 3. 그룹 스터디 조회/생성/관리 API
 ''''
 
-==== 그룹 카테고리 생성
+==== 3-1.그룹 카테고리 생성
 
 *Description*
 

--- a/src/asciidoc/api/group.adoc
+++ b/src/asciidoc/api/group.adoc
@@ -93,6 +93,15 @@ include::{snippets}/group-controller-rest-docs-test/create-group_success/http-re
 
 그룹 초대 코드 생성을 위해 사용합니다.
 
+기본적으로 초대 코드는 1일의 만료 기한을 가지고 있지만 유저의 설정에 의해 그 기한이 변경될 수 있습니다.
+따라서 초대 코드 반환 시 해당 코드의 만료 기한을 함께 반환합니다.
+
+이때, 남은 기한이 1일 이하이고, 초대 코드 요청이 들어오면 다시 1일로 설정합니다.
+
+남은 기한이 1일 이상인 경우 만료 기한을 갱신하지 않습니다.
+
+expiredDate 가 null 인 경우, 해당 초대 코드는 만료 기한이 없습니다.
+
 *Request* +
 
 '''
@@ -121,6 +130,8 @@ include::{snippets}/group-entry-controller-rest-docs-test/generate-entry-code_su
 
 해당 API 는 이미 만들어진 코드가 있을 때, 해당 코드의 만료 기한을 연장하는 API 입니다. 따라서 클라이언트는 먼저 1일 짜리 초대
 코드를 먼저 생성한 뒤, 해당 API 를 사용해 만료 기한을 추가로 설정하도록 해야 합니다.
+
+기한은 1일 ~ 30일이며, -1 을 입력 시 만료 날짜가 없는 초대 코드를 만들 수 있습니다.
 
 *Request* +
 

--- a/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
+++ b/src/main/java/com/studypals/domain/groupManage/api/GroupEntryController.java
@@ -55,6 +55,16 @@ public class GroupEntryController {
                 .body(response);
     }
 
+    @PatchMapping("/{groupId}/entry-code")
+    public ResponseEntity<Void> increaseCodeExpire(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long groupId,
+            @Valid @RequestBody UpdateEntryCodeReq req) {
+        groupEntryService.changeEntryCodeSetting(userId, groupId, req.day());
+
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/summary")
     public ResponseEntity<Response<GroupSummaryRes>> getGroupSummary(
             @RequestParam(required = true)

--- a/src/main/java/com/studypals/domain/groupManage/dao/GroupEntryCodeRedisRepository.java
+++ b/src/main/java/com/studypals/domain/groupManage/dao/GroupEntryCodeRedisRepository.java
@@ -1,5 +1,7 @@
 package com.studypals.domain.groupManage.dao;
 
+import java.util.Optional;
+
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +20,12 @@ import com.studypals.domain.groupManage.entity.GroupEntryCode;
  * @since 2025-04-15
  */
 @Repository
-public interface GroupEntryCodeRedisRepository extends CrudRepository<GroupEntryCode, String> {}
+public interface GroupEntryCodeRedisRepository extends CrudRepository<GroupEntryCode, String> {
+
+    /**
+     * indexed 된 groupId 에 대해 검색하는 메서드입니다.
+     * @param groupId 검색할 groupId
+     * @return 해당 groupId 를 가지고 있는 가장 처음 발견되는 hash entity
+     */
+    Optional<GroupEntryCode> findFirstByGroupId(Long groupId);
+}

--- a/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryCodeRes.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/GroupEntryCodeRes.java
@@ -1,9 +1,11 @@
 package com.studypals.domain.groupManage.dto;
 
+import java.time.LocalDateTime;
+
 /**
  * 클라이언트가 그룹 초대 코드 생성을 요청하면, 해당 그룹 ID와 생성된 코드를 반환합니다.
  *
  * @author s0o0bn
  * @since 2025-04-15
  */
-public record GroupEntryCodeRes(Long groupId, String code) {}
+public record GroupEntryCodeRes(Long groupId, String code, LocalDateTime expiredAt) {}

--- a/src/main/java/com/studypals/domain/groupManage/dto/UpdateEntryCodeReq.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/UpdateEntryCodeReq.java
@@ -1,28 +1,18 @@
 package com.studypals.domain.groupManage.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.AssertTrue;
 
 /**
- * 코드에 대한 전체적인 역할을 적습니다.
- * <p>
- * 코드에 대한 작동 원리 등을 적습니다.
- *
- * <p><b>상속 정보:</b><br>
- * 상속 정보를 적습니다.
- *
- * <p><b>주요 생성자:</b><br>
- * {@code ExampleClass(String example)}  <br>
- * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
- *
- * <p><b>빈 관리:</b><br>
- * 필요 시 빈 관리에 대한 내용을 적습니다.
- *
- * <p><b>외부 모듈:</b><br>
- * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ * 초대 코드 만료 기한을 재설정하는 request dto 입니다. -1 인 경우 만료가 없는 무제한 초대 코드입니다.
  *
  * @author jack8
  * @see
  * @since 2026-01-08
  */
-public record UpdateEntryCodeReq(@Min(1) @Max(7) Long day) {}
+public record UpdateEntryCodeReq(Long day) {
+
+    @AssertTrue(message = "day 는 -1 이거나 1 이상, 30 이하여야 합니다.")
+    public boolean isDayMatch() {
+        return (day == -1 || (day >= 1 && day <= 30));
+    }
+}

--- a/src/main/java/com/studypals/domain/groupManage/dto/UpdateEntryCodeReq.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/UpdateEntryCodeReq.java
@@ -2,6 +2,8 @@ package com.studypals.domain.groupManage.dto;
 
 import jakarta.validation.constraints.AssertTrue;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * 초대 코드 만료 기한을 재설정하는 request dto 입니다. -1 인 경우 만료가 없는 무제한 초대 코드입니다.
  *
@@ -12,6 +14,7 @@ import jakarta.validation.constraints.AssertTrue;
 public record UpdateEntryCodeReq(Long day) {
 
     @AssertTrue(message = "day 는 -1 이거나 1 이상, 30 이하여야 합니다.")
+    @JsonIgnore
     public boolean isDayMatch() {
         return (day == -1 || (day >= 1 && day <= 30));
     }

--- a/src/main/java/com/studypals/domain/groupManage/dto/UpdateEntryCodeReq.java
+++ b/src/main/java/com/studypals/domain/groupManage/dto/UpdateEntryCodeReq.java
@@ -1,0 +1,28 @@
+package com.studypals.domain.groupManage.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+/**
+ * 코드에 대한 전체적인 역할을 적습니다.
+ * <p>
+ * 코드에 대한 작동 원리 등을 적습니다.
+ *
+ * <p><b>상속 정보:</b><br>
+ * 상속 정보를 적습니다.
+ *
+ * <p><b>주요 생성자:</b><br>
+ * {@code ExampleClass(String example)}  <br>
+ * 주요 생성자와 그 매개변수에 대한 설명을 적습니다. <br>
+ *
+ * <p><b>빈 관리:</b><br>
+ * 필요 시 빈 관리에 대한 내용을 적습니다.
+ *
+ * <p><b>외부 모듈:</b><br>
+ * 필요 시 외부 모듈에 대한 내용을 적습니다.
+ *
+ * @author jack8
+ * @see
+ * @since 2026-01-08
+ */
+public record UpdateEntryCodeReq(@Min(1) @Max(7) Long day) {}

--- a/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryCode.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryCode.java
@@ -1,11 +1,16 @@
 package com.studypals.domain.groupManage.entity;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * redis에 저장되는 groupEntryCode에 대한 정보입니다.
@@ -23,5 +28,11 @@ public class GroupEntryCode {
     @Id
     private String code;
 
-    private Long id;
+    @Indexed
+    private Long groupId;
+
+    @TimeToLive(unit = TimeUnit.DAYS)
+    @Builder.Default
+    @Setter
+    private Long ttl = 1L;
 }

--- a/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryCode.java
+++ b/src/main/java/com/studypals/domain/groupManage/entity/GroupEntryCode.java
@@ -1,5 +1,6 @@
 package com.studypals.domain.groupManage.entity;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.annotation.Id;
@@ -30,6 +31,9 @@ public class GroupEntryCode {
 
     @Indexed
     private Long groupId;
+
+    @Setter
+    private LocalDateTime expireAt;
 
     @TimeToLive(unit = TimeUnit.DAYS)
     @Builder.Default

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
@@ -29,6 +29,15 @@ public interface GroupEntryService {
     GroupEntryCodeRes generateEntryCode(Long userId, Long groupId);
 
     /**
+     * 초대 코드 설정을 변경합니다.
+     * 설정 변경은 그룹장만 가능합니다. 현재는 expire date 변경만 가능합니다.
+     * @param userId 그룹장
+     * @param groupId 변경하고자 하는 그룹
+     * @param day 변경할 expire date, 현재 시점 기준 해당 일수 만큼 증가
+     */
+    void changeEntryCodeSetting(Long userId, Long groupId, Long day);
+
+    /**
      * 초대 코드로 그룹 대표 정보를 조회합니다.
      * 그룹장 포함 일부 멤버들의 프로필 이미지와 함께 조회합니다.
      *

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryService.java
@@ -43,7 +43,7 @@ public interface GroupEntryService {
      *
      * @param entryCode 그룹 초대 코드
      * @return 그룹 대표 정보
-     * @throws com.studypals.global.exceptions.exception.GroupException
+     * @throws com.studypals.global.exceptions.exception.GroupException 일치하는 entrycode 가 없는 경우
      */
     GroupSummaryRes getGroupSummary(String entryCode);
 

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -56,9 +56,15 @@ public class GroupEntryServiceImpl implements GroupEntryService {
     @Transactional(readOnly = true)
     public GroupEntryCodeRes generateEntryCode(Long userId, Long groupId) {
         authorityValidator.validateLeaderAuthority(userId, groupId);
-        String entryCode = entryCodeManager.generate(groupId);
+        String entryCode = entryCodeManager.getOrCreateCode(groupId);
 
         return new GroupEntryCodeRes(groupId, entryCode);
+    }
+
+    @Override
+    public void changeEntryCodeSetting(Long userId, Long groupId, Long day) {
+        authorityValidator.validateLeaderAuthority(userId, groupId);
+        entryCodeManager.increaseExpire(groupId, day);
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
+++ b/src/main/java/com/studypals/domain/groupManage/service/GroupEntryServiceImpl.java
@@ -13,6 +13,7 @@ import com.studypals.domain.groupManage.dto.*;
 import com.studypals.domain.groupManage.dto.mappers.GroupEntryRequestCustomMapper;
 import com.studypals.domain.groupManage.entity.Group;
 import com.studypals.domain.groupManage.entity.GroupConst;
+import com.studypals.domain.groupManage.entity.GroupEntryCode;
 import com.studypals.domain.groupManage.entity.GroupEntryRequest;
 import com.studypals.domain.groupManage.worker.*;
 import com.studypals.domain.memberManage.entity.Member;
@@ -56,9 +57,9 @@ public class GroupEntryServiceImpl implements GroupEntryService {
     @Transactional(readOnly = true)
     public GroupEntryCodeRes generateEntryCode(Long userId, Long groupId) {
         authorityValidator.validateLeaderAuthority(userId, groupId);
-        String entryCode = entryCodeManager.getOrCreateCode(groupId);
+        GroupEntryCode entryCode = entryCodeManager.getOrCreateCode(groupId);
 
-        return new GroupEntryCodeRes(groupId, entryCode);
+        return new GroupEntryCodeRes(groupId, entryCode.getCode(), entryCode.getExpireAt());
     }
 
     @Override

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
@@ -62,17 +62,17 @@ public class GroupEntryCodeManager {
      * <br>
      * <p>TTL은 Redis key 단위로 적용되며, 기존 TTL은 전달받은 값으로 덮어씌워집니다.</p>
      *
-     * @param code 만료 기간을 연장할 초대 코드
+     * @param groupId 만료 기간을 연장할 초대 코드 소유자 그룹 아이디
      * @param day 설정할 TTL 값 (단위는 Redis 설정에 따름)
      * @throws GroupException 초대 코드가 존재하지 않는 경우
      */
-    public void increaseExpire(String code, Long day) {
+    public void increaseExpire(Long groupId, Long day) {
         //
         GroupEntryCode entryCode = groupEntryCodeRepository
-                .findById(code)
+                .findFirstByGroupId(groupId)
                 .orElseThrow(() -> new GroupException(
                         GroupErrorCode.GROUP_CODE_NOT_FOUND,
-                        "[GroupEntryCodeManager#increaseExpire] unknown code while increase expire date"));
+                        "[GroupEntryCodeManager#increaseExpire] unknown group while increase expire date"));
 
         entryCode.setTtl(day);
         groupEntryCodeRepository.save(entryCode);

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
@@ -29,21 +29,80 @@ public class GroupEntryCodeManager {
 
     private final GroupEntryCodeRedisRepository groupEntryCodeRepository;
 
-    public String generate(Long groupId) {
-        String code = generateNonDuplicatedCode();
-        GroupEntryCode entryCode = new GroupEntryCode(code, groupId);
+    /**
+     * 지정된 groupId에 대한 초대 코드를 조회하거나 새로 생성합니다.
+     *
+     * <p>동작 방식은 다음과 같습니다.</p>
+     * 1. Redis에서 groupId로 기존 초대 코드가 존재하는지 조회합니다. <br>
+     * 2. 존재하면 해당 코드를 반환합니다. <br>
+     * 3. 존재하지 않으면 중복되지 않는 새 코드를 생성합니다. <br>
+     * 4. 초대 코드의 TTL을 설정하고 Redis에 저장합니다.
+     * <p>기존 코드가 존재하는 경우에도 TTL은 항상 갱신됩니다.</p>
+     *
+     * @param groupId 초대 코드가 속한 그룹의 식별자
+     * @return 조회되거나 새로 생성된 초대 코드 문자열
+     */
+    public String getOrCreateCode(Long groupId) {
+        GroupEntryCode entryCode = groupEntryCodeRepository
+                .findFirstByGroupId(groupId)
+                .orElseGet(() -> {
+                    String code = generateNonDuplicatedCode();
+                    return GroupEntryCode.builder().code(code).groupId(groupId).build();
+                });
+        entryCode.setTtl(1L);
         groupEntryCodeRepository.save(entryCode);
 
-        return code;
+        return entryCode.getCode();
     }
 
+    /**
+     * 지정된 초대 코드의 만료 기간(TTL)을 갱신합니다.
+     *
+     * <p>초대 코드가 Redis에 존재하지 않는 경우 예외를 발생시킵니다.</p>
+     * <br>
+     * <p>TTL은 Redis key 단위로 적용되며, 기존 TTL은 전달받은 값으로 덮어씌워집니다.</p>
+     *
+     * @param code 만료 기간을 연장할 초대 코드
+     * @param day 설정할 TTL 값 (단위는 Redis 설정에 따름)
+     * @throws GroupException 초대 코드가 존재하지 않는 경우
+     */
+    public void increaseExpire(String code, Long day) {
+        //
+        GroupEntryCode entryCode = groupEntryCodeRepository
+                .findById(code)
+                .orElseThrow(() -> new GroupException(
+                        GroupErrorCode.GROUP_CODE_NOT_FOUND,
+                        "[GroupEntryCodeManager#increaseExpire] unknown code while increase expire date"));
+
+        entryCode.setTtl(day);
+        groupEntryCodeRepository.save(entryCode);
+    }
+
+    /**
+     * 초대 코드에 해당하는 그룹 ID를 조회합니다.
+     *
+     * <p>초대 코드가 Redis에 존재하지 않는 경우 예외를 발생시킵니다.</p>
+     *
+     * @param entryCode 조회할 초대 코드
+     * @return 초대 코드가 속한 그룹의 식별자
+     * @throws GroupException 초대 코드가 존재하지 않는 경우
+     */
     public Long getGroupId(String entryCode) {
         return groupEntryCodeRepository
                 .findById(entryCode)
                 .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_CODE_NOT_FOUND))
-                .getId();
+                .getGroupId();
     }
 
+    /**
+     * 주어진 초대 코드가 특정 그룹에 속하는지 검증합니다.
+     *
+     * <p>초대 코드로 조회한 그룹 ID와 전달받은 그룹의 ID가 다를 경우 예외를 발생시킵니다.</p>
+     *
+     * @param group 검증 대상 그룹
+     * @param entryCode 검증할 초대 코드
+     * @throws GroupException 초대 코드가 다른 그룹에 속한 경우
+     */
     public void validateCodeBelongsToGroup(Group group, String entryCode) {
         Long actualGroupId = getGroupId(entryCode);
         if (!actualGroupId.equals(group.getId())) {
@@ -55,6 +114,15 @@ public class GroupEntryCodeManager {
         }
     }
 
+    /**
+     * 중복되지 않는 초대 코드를 생성합니다.
+     *
+     * <p>랜덤으로 코드를 생성한 뒤, Redis에 동일한 코드가 존재하는지 확인합니다.</p>
+     * <br>
+     * <p>중복되는 경우 재시도하며, 중복되지 않는 코드가 생성될 때까지 반복합니다.</p>
+     *
+     * @return 중복되지 않는 초대 코드 문자열
+     */
     private String generateNonDuplicatedCode() {
         String code;
         do {
@@ -64,6 +132,12 @@ public class GroupEntryCodeManager {
         return code;
     }
 
+    /**
+     * 주어진 초대 코드가 이미 Redis에 존재하는지 여부를 확인합니다.
+     *
+     * @param code 중복 여부를 확인할 초대 코드
+     * @return 이미 존재하면 true, 존재하지 않으면 false
+     */
     private boolean isDuplicatedCode(String code) {
         return groupEntryCodeRepository.existsById(code);
     }

--- a/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
+++ b/src/main/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManager.java
@@ -46,7 +46,7 @@ public class GroupEntryCodeManager {
      * @param groupId 초대 코드가 속한 그룹의 식별자
      * @return 조회되거나 새로 생성된 초대 코드 문자열
      */
-    public String getOrCreateCode(Long groupId) {
+    public GroupEntryCode getOrCreateCode(Long groupId) {
         LocalDateTime now = timeUtils.getRawLocalDateTime();
         LocalDateTime threshold = now.plusDays(1);
 
@@ -76,7 +76,7 @@ public class GroupEntryCodeManager {
 
         groupEntryCodeRepository.save(entryCode);
 
-        return entryCode.getCode();
+        return entryCode;
     }
 
     /**

--- a/src/main/java/com/studypals/global/redis/RedisConfig.java
+++ b/src/main/java/com/studypals/global/redis/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
@@ -30,6 +31,7 @@ import com.studypals.domain.studyManage.dao.StudyStatusRedisRepository;
  */
 @Configuration
 @EnableRedisRepositories(
+        enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP,
         basePackageClasses = {
             RefreshTokenRedisRepository.class,
             StudyStatusRedisRepository.class,

--- a/src/main/java/com/studypals/global/utils/TimeUtils.java
+++ b/src/main/java/com/studypals/global/utils/TimeUtils.java
@@ -46,6 +46,10 @@ public class TimeUtils {
         }
     }
 
+    public LocalDateTime getRawLocalDateTime() {
+        return LocalDateTime.now(clock);
+    }
+
     public LocalTime getTime() {
         LocalDateTime now = LocalDateTime.now(clock);
         return now.toLocalTime();

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,8 @@ public class GroupEntryControllerRestDocsTest extends RestDocsSupport {
     void generateEntryCode_success() throws Exception {
         // given
         Long groupId = 1L;
-        GroupEntryCodeRes entryCodeRes = new GroupEntryCodeRes(groupId, "A1B2C3");
+        LocalDateTime expiredAt = LocalDateTime.of(2026, 1, 1, 12, 0, 0);
+        GroupEntryCodeRes entryCodeRes = new GroupEntryCodeRes(groupId, "A1B2C3", expiredAt);
         Response<GroupEntryCodeRes> expected = CommonResponse.success(ResponseCode.GROUP_ENTRY_CODE, entryCodeRes);
 
         given(groupEntryService.generateEntryCode(any(), any())).willReturn(entryCodeRes);
@@ -77,6 +79,7 @@ public class GroupEntryControllerRestDocsTest extends RestDocsSupport {
                         responseFields(
                                 fieldWithPath("data.groupId").description("그룹 ID"),
                                 fieldWithPath("data.code").description("그룹 초대 코드 | 6자리의 대문자 알파벳, 숫자 조합"),
+                                fieldWithPath("data.expiredAt").description("해당 코드가 만료되는 날짜 및 시간 | null 인 경우 무제한"),
                                 fieldWithPath("code").description("응답 코드"),
                                 fieldWithPath("status").description("응답 상태"),
                                 fieldWithPath("message").description("응답 메시지")),

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
@@ -109,7 +109,7 @@ public class GroupEntryControllerRestDocsTest extends RestDocsSupport {
                                 .attributes(constraints("not null"))),
                         requestFields(fieldWithPath("day")
                                 .description("연장할 초대 코드의 그룹 아이디")
-                                .attributes(constraints("not null, min(0), max(7)")))));
+                                .attributes(constraints("not null, min(0), max(30) || -1(만료 날짜 없음)")))));
     }
 
     @Test

--- a/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/restDocsTest/GroupEntryControllerRestDocsTest.java
@@ -84,6 +84,32 @@ public class GroupEntryControllerRestDocsTest extends RestDocsSupport {
     }
 
     @Test
+    @WithMockUser
+    void increaseCodeExpire_success() throws Exception {
+        // given
+        Long groupId = 1L;
+        Long day = 7L;
+        UpdateEntryCodeReq req = new UpdateEntryCodeReq(day);
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/groups/{groupId}/entry-code", groupId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(req)));
+
+        // then
+        result.andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                        httpRequest(),
+                        httpResponse(),
+                        pathParameters(parameterWithName("groupId")
+                                .description("초대 코드를 연장할 그룹의 아이디")
+                                .attributes(constraints("not null"))),
+                        requestFields(fieldWithPath("day")
+                                .description("연장할 초대 코드의 그룹 아이디")
+                                .attributes(constraints("not null, min(0), max(7)")))));
+    }
+
+    @Test
     void getGroupSummary_success() throws Exception {
         // given
         String entryCode = "A1B2C3";

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -19,10 +20,7 @@ import org.springframework.data.domain.SliceImpl;
 import com.studypals.domain.chatManage.entity.ChatRoom;
 import com.studypals.domain.chatManage.worker.ChatRoomWriter;
 import com.studypals.domain.groupManage.dto.*;
-import com.studypals.domain.groupManage.entity.Group;
-import com.studypals.domain.groupManage.entity.GroupEntryRequest;
-import com.studypals.domain.groupManage.entity.GroupMember;
-import com.studypals.domain.groupManage.entity.GroupRole;
+import com.studypals.domain.groupManage.entity.*;
 import com.studypals.domain.groupManage.worker.*;
 import com.studypals.domain.memberManage.entity.Member;
 import com.studypals.domain.memberManage.worker.MemberReader;
@@ -74,6 +72,9 @@ public class GroupEntryServiceTest {
     @Mock
     private GroupEntryRequest mockEntryRequest;
 
+    @Mock
+    private GroupEntryCode mockGroupEntryCode;
+
     @InjectMocks
     private GroupEntryServiceImpl groupEntryService;
 
@@ -82,10 +83,13 @@ public class GroupEntryServiceTest {
         // given
         Long userId = 1L;
         Long groupId = 1L;
+        LocalDateTime now = LocalDateTime.now();
         String entryCode = "A1B2C3";
-        GroupEntryCodeRes expected = new GroupEntryCodeRes(groupId, entryCode);
+        GroupEntryCodeRes expected = new GroupEntryCodeRes(groupId, entryCode, now);
 
-        given(entryCodeManager.getOrCreateCode(groupId)).willReturn(entryCode);
+        given(entryCodeManager.getOrCreateCode(groupId)).willReturn(mockGroupEntryCode);
+        given(mockGroupEntryCode.getCode()).willReturn(entryCode);
+        given(mockGroupEntryCode.getExpireAt()).willReturn(now);
 
         // when
         GroupEntryCodeRes actual = groupEntryService.generateEntryCode(userId, groupId);

--- a/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/service/GroupEntryServiceTest.java
@@ -85,7 +85,7 @@ public class GroupEntryServiceTest {
         String entryCode = "A1B2C3";
         GroupEntryCodeRes expected = new GroupEntryCodeRes(groupId, entryCode);
 
-        given(entryCodeManager.generate(groupId)).willReturn(entryCode);
+        given(entryCodeManager.getOrCreateCode(groupId)).willReturn(entryCode);
 
         // when
         GroupEntryCodeRes actual = groupEntryService.generateEntryCode(userId, groupId);

--- a/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManagerTest.java
+++ b/src/test/java/com/studypals/domain/groupManage/worker/GroupEntryCodeManagerTest.java
@@ -41,7 +41,7 @@ public class GroupEntryCodeManagerTest {
         Long groupId = 1L;
 
         // when
-        String code = entryCodeManager.generate(groupId);
+        String code = entryCodeManager.getOrCreateCode(groupId);
 
         // then
         assertThat(code).isNotNull();
@@ -54,7 +54,8 @@ public class GroupEntryCodeManagerTest {
         // given
         Long groupId = 1L;
         String entryCode = "entry code";
-        GroupEntryCode groupEntryCode = new GroupEntryCode(entryCode, groupId);
+        GroupEntryCode groupEntryCode =
+                GroupEntryCode.builder().code(entryCode).groupId(groupId).build();
 
         given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
 
@@ -85,7 +86,8 @@ public class GroupEntryCodeManagerTest {
         // given
         Group group = Group.builder().id(1L).build();
         String entryCode = "entry code";
-        GroupEntryCode groupEntryCode = new GroupEntryCode(entryCode, group.getId());
+        GroupEntryCode groupEntryCode =
+                GroupEntryCode.builder().code(entryCode).groupId(group.getId()).build();
 
         given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
 
@@ -99,7 +101,8 @@ public class GroupEntryCodeManagerTest {
         // given
         Group group = Group.builder().id(1L).build();
         String entryCode = "entry code";
-        GroupEntryCode groupEntryCode = new GroupEntryCode(entryCode, 2L);
+        GroupEntryCode groupEntryCode =
+                GroupEntryCode.builder().code(entryCode).groupId(2L).build();
 
         given(entryCodeRepository.findById(entryCode)).willReturn(Optional.of(groupEntryCode));
 

--- a/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
+++ b/src/test/java/com/studypals/integrationTest/GroupEntryIntegrationTest.java
@@ -68,7 +68,8 @@ public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
         // given
         CreateUserVar user = createUser();
         CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
-        GroupEntryCode entryCode = new GroupEntryCode("A1B2C3", group.groupId());
+        GroupEntryCode entryCode =
+                GroupEntryCode.builder().code("A1B2C3").groupId(group.groupId()).build();
 
         entryCodeRedisRepository.save(entryCode);
 
@@ -92,7 +93,8 @@ public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
         CreateUserVar initUser = createUser();
         CreateGroupVar group = createGroup(initUser.getUserId(), "group", "tag", false);
         CreateUserVar user = createUser("member_username", "member");
-        GroupEntryCode groupEntryCode = new GroupEntryCode("1A2B3C", group.groupId());
+        GroupEntryCode groupEntryCode =
+                GroupEntryCode.builder().code("A1B2C3").groupId(group.groupId()).build();
         GroupEntryReq req = new GroupEntryReq(group.groupId(), groupEntryCode.getCode());
 
         entryCodeRedisRepository.save(groupEntryCode);
@@ -114,7 +116,8 @@ public class GroupEntryIntegrationTest extends AbstractGroupIntegrationTest {
         // given
         CreateUserVar user = createUser();
         CreateGroupVar group = createGroup(user.getUserId(), "group", "tag");
-        GroupEntryCode groupEntryCode = new GroupEntryCode("1A2B3C", group.groupId());
+        GroupEntryCode groupEntryCode =
+                GroupEntryCode.builder().code("A1B2C3").groupId(group.groupId()).build();
         GroupEntryReq req = new GroupEntryReq(group.groupId(), groupEntryCode.getCode());
 
         entryCodeRedisRepository.save(groupEntryCode);


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #158

## ✨ 구현 기능 명세

### 1. 초대 코드 요청
그룹 초대 코드 생성 요청 시, 이미 redis 에 존재하는 경우 해당 코드를 반환합니다. 새롭게 생성하는 경우, 만료 날짜를 1일 뒤로 잡은 뒤 반환합니다. 또한, 해당 코드가 만료되는 날짜 및 시각을 같이 반환합니다.

이미 존재하는 경우, 만료 날짜가 오늘로부터 1일 이내인 경우, 1일 뒤로 재설정합니다.
이미 존재하고, 만료 날짜가 오늘로부터 1일 이후인 경우, 재설정 없이 그대로 반환합니다.
만료 날짜가 null 인 경우, 이는 만료가 없는 무한정 사용할 수 있는 초대 코드입니다.


### 2. 초대 코드 만료 기한 재설정
이미 특정 그룹에 초대 코드가 이미 존재하는 경우, 해당 코드의 만료 기한을 최소 1일 ~ 최대 30일로 설정할 수 있습니다.  만료 기한을 -1 로 두어 요청하는 경우, 만료 기한이 없는, 무제한 초대 코드로 갱신할 수 있습니다.

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->

## ✅ PR Point

### `Indexed` 어노테이션
해당 어노테이션은 해시 내부의 필드 값에 대해 검색이 가능하도록 합니다. 즉, 기본적으로 Hash 자료구조는 Hash key 에 대해서만 검색이 가능하고 내부 필드에 대한 검색이 불가능합니다.  이를 위해 `@Indexed` 어노테이션을 필드에 붙여 필드 값 기반으로 검색을 수행할 수 있습니다.

내부적으로 redis 는 해당 어노테이션이 붙은 필드에 대해 `SET` 자료형을 사용합니다. SET 자료구조는 해당 필드 값을 key 로 가지고 있으며, 내부 값으로 해시 키를 가지는, 일종의 역참조 포인터를 형성합니다.

```
                 (Redis Hash)
   groupEntryCode:{id=10}  ───────────────────────────┐
   ├─ code      = "A1B2C3"                            │
   ├─ groupId   = 7   (@Indexed)                      │
   └─ expireAt  = 2026-01-09T12:00                    │
                                                      │
                                                      │
                                                      │
                           역참조 인덱스 (SET)
                groupEntryCode:groupId:7  ─────────────┘
                (key = "필드명:필드값")
                members = {
                  "groupEntryCode:{id=10}",
                  "groupEntryCode:{id=11}"
                }
```
> 위는 일종의 예시이며, 실제 해당 방식으로 구현되지는 않습니다.

해당 SET 자료구조는 원본에 대해 TTL 을 공유하지 않습니다. 따라서 spring redis 에서 자체적으로 해당 SET 자료구조를 삭제하기 위해 다음과 같은 SET 자료구조를 같이 운영합니다
```
SET: entryCode:PWYX39:idx
```
따라서, 실제로 Redis 에 저장되는 데이터는 다음과 같습니다.

```
                (TTL 23h)
        ┌──────────────────────┐
        │ Hash entryCode:PWYX39 │
        │  - code = PWYX39      │
        │  - groupId = 6        │
        │  - ...                │
        └──────────────────────┘
                   │
                   │  (저장 시 인덱스에도 반영)
                   ▼

┌──────────────────────────────┐
│ Set entryCode                 │   ← 전체 ID 집합 (TTL 없음)
│  - PWYX39                     │
└──────────────────────────────┘

┌──────────────────────────────┐
│ Set entryCode:groupId:6       │   ← @Indexed(groupId) 인덱스 (TTL 없음)
│  - PWYX39                     │
└──────────────────────────────┘

┌──────────────────────────────┐
│ Set entryCode:PWYX39:idx      │   ← “정리 대상 인덱스 목록” (TTL 없음)
│  - entryCode:groupId:6        │
│  - (다른 @Indexed 있으면 더)  │
└──────────────────────────────┘
```

spring redis 는 `entryCode:PWYX39` 가 TTL 에 의해 만료되어 삭제되면, 삭제 이벤트를 수신합니다. 이때, 원본 데이터는 이미 삭제된 직후라 내부의 값(특히, groupId) 은 모른 채 hash key 의 존재만 알고 있습니다.

따라서, spring redis 는 `entryCode:PWYX39:idx` (TTL = null) 를 참조하여 groupId 를 가져오고, 이를 토대로 `entryCode:groupId:6` 및, 참조한 `:idx` 를 삭제합니다.  마찬가지로, `SET EntryCode` 역시 삭제합니다.

이를 위해 redis 및 spring 에 Expire 이벤트에 대한 이벤트 발행/리스너를 설정하였습니다. 이를 `notify-keyspace-event Ex` 라 합니다.

`RedisConfig` 에서 이러한 이벤트를 수신하여 인덱스를 제거하기 위해선 `enableKeyspaceEvents` 를 설정하여야 하며, 이 경우 `shadowCopy` 가 자동으로 생성됩니다. `shadowCopy` 는 실제 원본 데이터보다 TTL 이 약 5분 정도 더 긴 복사된 데이터이며 만료로 삭제 시 해당 이벤트가 서버로 도착할 때 key 뿐만 아니라 내부 필드 값도 같이 주기 위함입니다. 이때 복사되는 데이터는 `:phantom` 이라는 postfix 를 가지고 있습니다.

그러나 현재는 `:idx` 를 통한 인덱스를 통해 충분히 삭제시킬 수 있고, 삭제 시 그 외 필드가 필요하지 않기 때문에 `shadow copy` 를 껐습니다. 해당 기능은 메모리 오버헤드가 큰 편입니다.


### 만료 시간 재설정
`@TimeToLive` 어노테이션은 해당 데이터의 TTL 을 설정합니다. 해당 값은 언제든지 덮어 씌워질 수 있으며 실제 TTL 에 영향을 줄 뿐만 아니라 필드로서도 동일한 값이 저장됩니다.

가령 TTL 의 timeunit 을 TimeUnit.DAY 로 하고 그 값을 1로 설정하면, redis 에는 `ttl : {value}` 가 저장됩니다. ttl 을 의도적으로 null 로 설정하면 TTL 이 없는 데이터가 되며 덮어씌워 저장하면 갱신이 됩니다.

이를 통해 코드 조회 시 TTL 이 null / -1 이면(-1 이여도 TTL null 과 동일) 갱신하지 않고, expiredDate 필드를 추가하여, 현재 존재하는 코드의 만료가 expiredDate 와 하루 이내 차이라면 새롭게 갱신(TTL 만) / 아닌 경우 그대로 반환하고 있습니다.



## 😭 어려웠던 점

Redis 설정이 참 힘들었습니다... 
